### PR TITLE
Fix disappearing menu in outline view

### DIFF
--- a/org.eclipse.lsp4e/plugin.xml
+++ b/org.eclipse.lsp4e/plugin.xml
@@ -281,7 +281,7 @@
                label="Link with Editor"
                style="toggle">
             <visibleWhen>
-               <reference definitionId="org.eclipse.lsp4e.activePartHasCNFOutlinePage" />
+               <reference definitionId="org.eclipse.lsp4e.activeEditorHasCNFOutlinePage" />
             </visibleWhen>
          </command>
       </menuContribution>
@@ -293,7 +293,7 @@
                label="Show Kind"
                style="toggle">
             <visibleWhen>
-               <reference definitionId="org.eclipse.lsp4e.activePartHasCNFOutlinePage" />
+               <reference definitionId="org.eclipse.lsp4e.activeEditorHasCNFOutlinePage" />
             </visibleWhen>
          </command>
       </menuContribution>
@@ -305,7 +305,7 @@
                label="Hide...">
             <visibleWhen>
                <reference
-                     definitionId="org.eclipse.lsp4e.activePartHasCNFOutlinePage">
+                     definitionId="org.eclipse.lsp4e.activeEditorHasCNFOutlinePage">
                </reference>
             </visibleWhen>
          </menu>


### PR DESCRIPTION
Ensures that the actions Link with editor, Show Kind, Hide... stay visible if an LSP editor becomes active.

See https://github.com/eclipse-lsp4e/lsp4e/issues/254#issuecomment-2483262272

This PR is related to issue #254.