### PR TITLE
Semantic tokens from LS available in the Java editor

### DIFF
--- a/org.eclipse.lsp4e.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.jdt/META-INF/MANIFEST.MF
@@ -3,7 +3,10 @@ Bundle-ManifestVersion: 2
 Bundle-Name: JDT Integration for LSP4E
 Bundle-SymbolicName: org.eclipse.lsp4e.jdt;singleton:=true
 Bundle-Version: 0.13.6.qualifier
+Export-Package: org.eclipse.lsp4e.jdt
 Automatic-Module-Name: org.eclipse.lsp4e.jdt
+Bundle-Activator: org.eclipse.lsp4e.jdt.LanguageServerJdtPlugin
+Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ClassPath: .
 Bundle-Localization: plugin
@@ -11,8 +14,13 @@ Bundle-Vendor: Eclipse LSP4E
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.jface.text;bundle-version="3.13.0",
  org.eclipse.ui;bundle-version="3.108.0",
- org.eclipse.lsp4e;bundle-version="0.18.13",
+ org.eclipse.lsp4e;bundle-version="0.18.20",
  org.eclipse.jdt.core;bundle-version="3.20.0",
- org.eclipse.jdt.ui;bundle-version="3.20.0",
+ org.eclipse.jdt.ui;bundle-version="3.34.0",
  org.eclipse.swt,
- org.eclipse.lsp4j
+ org.eclipse.core.resources,
+ org.eclipse.lsp4j,
+ org.eclipse.lsp4j.jsonrpc,
+ org.eclipse.core.resources,
+ org.eclipse.jdt.annotation,
+ org.eclipse.ui.editors

--- a/org.eclipse.lsp4e.jdt/plugin.properties
+++ b/org.eclipse.lsp4e.jdt/plugin.properties
@@ -11,3 +11,4 @@
 ###############################################################################
 
 lsCompletionComputer_name=Language Server Proposals
+languageservers.jdt.preferences.page=Java

--- a/org.eclipse.lsp4e.jdt/plugin.xml
+++ b/org.eclipse.lsp4e.jdt/plugin.xml
@@ -40,5 +40,26 @@
             name="LS Java Quick Proposals">
       </quickAssistProcessor>
    </extension>
+   <extension
+         point="org.eclipse.jdt.ui.semanticTokens">
+      <provider
+            class="org.eclipse.lsp4e.jdt.LSJavaSemanticTokensProvider">
+      </provider>
+   </extension>
+   <extension
+         point="org.eclipse.core.runtime.preferences">
+      <initializer
+            class="org.eclipse.lsp4e.jdt.preferences.LspJdtPrefsInitializer">
+      </initializer>
+   </extension>
+   <extension
+         point="org.eclipse.ui.preferencePages">
+      <page
+            category="org.eclipse.lsp4e.preferences"
+            class="org.eclipse.lsp4e.jdt.preferences.LspJdtPreferencesPage"
+            id="org.eclipse.lsp4e.jdt"
+            name="%languageservers.jdt.preferences.page">
+      </page>
+   </extension>
 
 </plugin>

--- a/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/JavaSemanticTokensProcessor.java
+++ b/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/JavaSemanticTokensProcessor.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Broadcom, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Broadcom, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.jdt;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jdt.ui.text.java.ISemanticTokensProvider;
+import org.eclipse.lsp4e.operations.semanticTokens.AbstractcSemanticTokensDataStreamProcessor;
+import org.eclipse.lsp4j.Position;
+
+class JavaSemanticTokensProcessor extends AbstractcSemanticTokensDataStreamProcessor<ISemanticTokensProvider.TokenType, ISemanticTokensProvider.SemanticToken> {
+	
+	public JavaSemanticTokensProcessor(final Function<String, ISemanticTokensProvider.@Nullable TokenType> tokenTypeMapper,
+			final Function<Position, Integer> offsetMapper) {
+		super(offsetMapper, tokenTypeMapper);
+	}
+
+	@Override
+	protected ISemanticTokensProvider.@Nullable SemanticToken createTokenData(
+			ISemanticTokensProvider.@Nullable TokenType tt, int offset, int length, List<String> tokenModifiers) {
+		if (tt != null) {
+			return new ISemanticTokensProvider.SemanticToken(offset, length, tt);
+		}
+		return null;
+	}
+}

--- a/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LSJavaSemanticTokensProvider.java
+++ b/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LSJavaSemanticTokensProvider.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Broadcom Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  - Alex Boyko (Broadcom Inc.) - Initial implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.jdt;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.core.resources.IResource;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.ui.text.java.ISemanticTokensProvider;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.lsp4e.LSPEclipseUtils;
+import org.eclipse.lsp4e.LanguageServerPlugin;
+import org.eclipse.lsp4e.internal.CancellationUtil;
+import org.eclipse.lsp4e.jdt.preferences.PreferenceConstants;
+import org.eclipse.lsp4e.operations.semanticTokens.SemanticHighlightReconcilerStrategy;
+import org.eclipse.lsp4e.operations.semanticTokens.SemanticTokensClient;
+import org.eclipse.lsp4j.SemanticTokens;
+import org.eclipse.lsp4j.SemanticTokensLegend;
+
+public class LSJavaSemanticTokensProvider implements ISemanticTokensProvider {
+	
+	private static final int TIMEOUT_SEMANTIC_TOKENS = 300;
+	
+	@SuppressWarnings("null")
+	@Override
+	public Collection<ISemanticTokensProvider.SemanticToken> computeSemanticTokens(CompilationUnit ast) {
+		IPreferenceStore prefStore = LanguageServerPlugin.getDefault().getPreferenceStore();
+		LanguageServerJdtPlugin plugin = LanguageServerJdtPlugin.getDefault();
+		if (plugin == null) {
+			throw new IllegalStateException("Plugin hasn't been started!");
+		}
+		IPreferenceStore jstPrefStore = plugin.getPreferenceStore();
+		
+		if (prefStore.getBoolean(SemanticHighlightReconcilerStrategy.SEMANTIC_HIGHLIGHT_RECONCILER_DISABLED)
+				|| !jstPrefStore.getBoolean(PreferenceConstants.PREF_SEMANTIC_TOKENS_SWITCH)) {
+			return Collections.emptyList();
+		}
+		
+		IResource resource = ast.getTypeRoot().getResource();
+		if (resource == null) {
+			return Collections.emptyList();
+		}
+		
+		final IDocument theDocument = LSPEclipseUtils.getDocument(resource);
+		if (theDocument == null) {
+			return Collections.emptyList();
+		}
+		
+		try {
+			return SemanticTokensClient.DEFAULT.requestFullSemanticTokens(theDocument, (legend, semanticTokens) -> convertTokens(legend, theDocument, semanticTokens))
+				.thenApply(o -> o.orElse(Collections.emptyList())).get(TIMEOUT_SEMANTIC_TOKENS, TimeUnit.MILLISECONDS);
+		} catch (TimeoutException e) {
+			LanguageServerPlugin.logWarning("Timed out after waiting for %dms for semantic tokens from Language Servers".formatted(TIMEOUT_SEMANTIC_TOKENS), e);
+		} catch (InterruptedException e) {
+			LanguageServerPlugin.logError(e);
+			Thread.currentThread().interrupt();
+		} catch (ExecutionException e) {
+			if (!CancellationUtil.isRequestCancelledException(e)) { // do not report error if the server has cancelled the request
+				LanguageServerPlugin.logError("Failed to fetch semantic tokens for '%s' from Language Servers".formatted(resource.getLocation()), e);
+			}
+		}		
+		return Collections.emptyList();
+	}
+	
+	private List<ISemanticTokensProvider.SemanticToken> convertTokens(@Nullable SemanticTokensLegend legend, IDocument theDocument, @Nullable SemanticTokens semanticTokens) {
+		if (semanticTokens == null) {
+			return Collections.emptyList();
+		}
+		if (legend == null) {
+			return Collections.emptyList();
+		}
+		return new JavaSemanticTokensProcessor(this::mapToTokenType, p -> {
+			try {
+				return LSPEclipseUtils.toOffset(p, theDocument);
+			} catch (BadLocationException e) {
+				throw new RuntimeException(e);
+			}
+		}).getTokensData(semanticTokens.getData(), legend);
+	}
+	
+	private ISemanticTokensProvider.TokenType mapToTokenType(String tokeTypeStr) {
+		return switch (tokeTypeStr) {
+			case "method" -> ISemanticTokensProvider.TokenType.METHOD;
+			case "comment" -> ISemanticTokensProvider.TokenType.SINGLE_LINE_COMMENT;
+			case "variable" -> ISemanticTokensProvider.TokenType.LOCAL_VARIABLE;
+			case "type" -> ISemanticTokensProvider.TokenType.CLASS;
+			case "property" -> ISemanticTokensProvider.TokenType.FIELD;
+			case "keyword" -> ISemanticTokensProvider.TokenType.KEYWORD;
+			case "operator" -> ISemanticTokensProvider.TokenType.OPERATOR;
+			case "number" -> ISemanticTokensProvider.TokenType.NUMBER;
+			case "string" -> ISemanticTokensProvider.TokenType.STRING;
+			case "enum" -> ISemanticTokensProvider.TokenType.ENUM;
+			case "class" -> ISemanticTokensProvider.TokenType.CLASS;
+			case "macro" -> ISemanticTokensProvider.TokenType.STATIC_METHOD_INVOCATION;
+			case "parameter" -> ISemanticTokensProvider.TokenType.PARAMETER_VARIABLE;
+			default -> ISemanticTokensProvider.TokenType.DEFAULT;
+		};
+	}
+
+
+}

--- a/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LanguageServerJdtPlugin.java
+++ b/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LanguageServerJdtPlugin.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Broadcom, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Broadcom, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.jdt;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jdt.internal.ui.javaeditor.JavaEditor;
+import org.eclipse.jface.util.IPropertyChangeListener;
+import org.eclipse.jface.util.PropertyChangeEvent;
+import org.eclipse.lsp4e.jdt.preferences.PreferenceConstants;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IEditorReference;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.osgi.framework.BundleContext;
+
+public class LanguageServerJdtPlugin extends AbstractUIPlugin {
+	
+	private static @Nullable LanguageServerJdtPlugin plugin;
+	
+	private final IPropertyChangeListener prefsLisetner = new IPropertyChangeListener() {
+		
+		@SuppressWarnings("restriction")
+		@Override
+		public void propertyChange(PropertyChangeEvent event) {
+			if (PreferenceConstants.PREF_SEMANTIC_TOKENS_SWITCH.equals(event.getProperty())) {
+				for (IWorkbenchWindow window : PlatformUI.getWorkbench().getWorkbenchWindows()) {
+					for (IWorkbenchPage page : window.getPages()) {
+						for (IEditorReference editorRef : page.getEditorReferences()) {
+							IEditorPart editor = editorRef.getEditor(false);
+							if (editor instanceof JavaEditor je) {
+								je.refreshSemanticHighlighting();
+							}
+						}
+					}
+				}
+			}
+		}
+	};
+	
+	public static final @Nullable LanguageServerJdtPlugin getDefault() {
+		return plugin;
+	}
+
+	@Override
+	public void start(BundleContext context) throws Exception {
+		super.start(context);
+		plugin = this;
+		getPreferenceStore().addPropertyChangeListener(prefsLisetner);
+	}
+
+	@Override
+	public void stop(BundleContext context) throws Exception {
+		getPreferenceStore().removePropertyChangeListener(prefsLisetner);
+		plugin = null;
+		super.stop(context);
+	}
+
+}

--- a/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/preferences/LspJdtPreferencesPage.java
+++ b/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/preferences/LspJdtPreferencesPage.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Broadcom, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Broadcom, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.jdt.preferences;
+
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.lsp4e.internal.NullSafetyHelper;
+import org.eclipse.lsp4e.jdt.LanguageServerJdtPlugin;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+
+public final class LspJdtPreferencesPage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+
+	@Override
+	public void init(IWorkbench workbench) {
+		setPreferenceStore(NullSafetyHelper.castNonNull(LanguageServerJdtPlugin.getDefault()).getPreferenceStore());
+	}
+
+	@Override
+	protected void createFieldEditors() {
+		Composite fieldEditorParent = getFieldEditorParent();
+		
+		addField(new BooleanFieldEditor(PreferenceConstants.PREF_SEMANTIC_TOKENS_SWITCH, "Embedded languages syntax highlighting in Java Editor", fieldEditorParent));
+	}
+
+}

--- a/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/preferences/LspJdtPrefsInitializer.java
+++ b/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/preferences/LspJdtPrefsInitializer.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Broadcom, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Broadcom, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.jdt.preferences;
+
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.lsp4e.jdt.LanguageServerJdtPlugin;
+
+public final class LspJdtPrefsInitializer extends AbstractPreferenceInitializer {
+	
+	public LspJdtPrefsInitializer() {
+	}
+
+	@Override
+	public void initializeDefaultPreferences() {
+		LanguageServerJdtPlugin plugin = LanguageServerJdtPlugin.getDefault();
+		if (plugin == null) {
+			throw new IllegalStateException("Plugin hasn't been started!");
+		}
+		IPreferenceStore store = plugin.getPreferenceStore();
+		
+		store.setDefault(PreferenceConstants.PREF_SEMANTIC_TOKENS_SWITCH, false);
+	}
+
+}

--- a/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/preferences/PreferenceConstants.java
+++ b/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/preferences/PreferenceConstants.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Broadcom, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Broadcom, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.jdt.preferences;
+
+public final class PreferenceConstants {
+
+	public static final String PREF_SEMANTIC_TOKENS_SWITCH = "semanticHighlightReconciler.java.enabled";
+
+}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensDataStreamProcessorTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensDataStreamProcessorTest.java
@@ -35,7 +35,7 @@ public class SemanticTokensDataStreamProcessorTest extends AbstractTest {
 				new StyleRange(24, 7, SemanticTokensTestUtil.RED, null)//
 				);
 
-		List<StyleRange> styleRanges = processor.getStyleRanges(expectedStream, getSemanticTokensLegend());
+		List<StyleRange> styleRanges = processor.getTokensData(expectedStream, getSemanticTokensLegend());
 
 		assertEquals(expectedStyleRanges, styleRanges);
 	}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensLegendProviderTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/semanticTokens/SemanticTokensLegendProviderTest.java
@@ -8,7 +8,8 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.test.semanticTokens;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
 
@@ -16,7 +17,7 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.lsp4e.LanguageServerWrapper;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
-import org.eclipse.lsp4e.operations.semanticTokens.SemanticHighlightReconcilerStrategy;
+import org.eclipse.lsp4e.operations.semanticTokens.SemanticTokensClient;
 import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.junit.Test;
@@ -36,7 +37,7 @@ public class SemanticTokensLegendProviderTest extends AbstractTestWithProject {
 		LanguageServerWrapper wrapper = LanguageServiceAccessor.getLSWrappers(file, c -> Boolean.TRUE).iterator()
 		.next();
 
-		final var semanticTokensLegend = new SemanticHighlightReconcilerStrategy().getSemanticTokensLegend(wrapper);
+		final var semanticTokensLegend = SemanticTokensClient.DEFAULT.getSemanticTokensLegend(wrapper);
 		assertNotNull(semanticTokensLegend);
 		assertEquals(tokenTypes, semanticTokensLegend.getTokenTypes());
 		assertEquals(tokenModifiers, semanticTokensLegend.getTokenModifiers());

--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -55,6 +55,7 @@ Export-Package: org.eclipse.lsp4e;x-friends:="org.eclipse.lsp4e.debug,org.eclips
  org.eclipse.lsp4e.operations.format;x-internal:=true,
  org.eclipse.lsp4e.operations.hover;x-internal:=true,
  org.eclipse.lsp4e.operations.rename;x-internal:=true,
+ org.eclipse.lsp4e.operations.semanticTokens,
  org.eclipse.lsp4e.outline;x-internal:=true,
  org.eclipse.lsp4e.server;version="0.1.0",
  org.eclipse.lsp4e.ui

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/AbstractcSemanticTokensDataStreamProcessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/AbstractcSemanticTokensDataStreamProcessor.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Broadcom, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Broadcom, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.operations.semanticTokens;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.SemanticTokensLegend;
+
+public abstract class AbstractcSemanticTokensDataStreamProcessor<T, V> {
+
+	private final Function<Position, Integer> offsetMapper;
+	private final Function<String, @Nullable T> tokenTypeMapper;
+
+	public AbstractcSemanticTokensDataStreamProcessor(Function<Position, Integer> offsetMapper,
+			Function<String, @Nullable T> tokenTypeMapper) {
+		this.offsetMapper = offsetMapper;
+		this.tokenTypeMapper = tokenTypeMapper;
+	}
+
+	/**
+	 * Get the IDE Tokens for the given data stream and tokens legend.
+	 *
+	 * @param dataStream
+	 * @param semanticTokensLegend
+	 */
+	public final List<V> getTokensData(final List<Integer> dataStream,
+			final SemanticTokensLegend semanticTokensLegend) {
+		final var tokens = new ArrayList<V>(dataStream.size() / 5);
+
+		int idx = 0;
+		int prevLine = 0;
+		int line = 0;
+		int offset = 0;
+		int length = 0;
+		String tokenType = null;
+		for (Integer data : dataStream) {
+			switch (idx % 5) {
+			case 0: // line
+				line += data;
+				break;
+			case 1: // offset
+				if (line == prevLine) {
+					offset += data;
+				} else {
+					offset = offsetMapper.apply(new Position(line, data));
+				}
+				break;
+			case 2: // length
+				length = data;
+				break;
+			case 3: // token type
+				tokenType = tokenType(data, semanticTokensLegend.getTokenTypes());
+				break;
+			case 4: // token modifier
+				prevLine = line;
+				@Nullable V token = createTokenData(tokenType == null ? null : tokenTypeMapper.apply(tokenType), offset, length, tokenModifiers(data, semanticTokensLegend.getTokenModifiers()));
+				if (token != null) {
+					tokens.add(token);
+				}
+				break;
+			}
+			idx++;
+		}
+		return tokens;
+	}
+
+	abstract protected @Nullable V createTokenData(@Nullable T tokenType, int offset, int length, List<String> tokenModifiers);
+
+	private @Nullable String tokenType(final Integer data, final List<String> legend) {
+		try {
+			return legend.get(data);
+		} catch (IndexOutOfBoundsException e) {
+			return null; // no match
+		}
+	}
+
+	private List<String> tokenModifiers(final Integer data, final List<String> legend) {
+		if (data.intValue() == 0) {
+			return Collections.emptyList();
+		}
+		final var bitSet = BitSet.valueOf(new long[] { data });
+		final var tokenModifiers = new ArrayList<String>();
+		for (int i = bitSet.nextSetBit(0); i >= 0; i = bitSet.nextSetBit(i + 1)) {
+			try {
+				tokenModifiers.add(legend.get(i));
+			} catch (IndexOutOfBoundsException e) {
+				// no match
+			}
+		}
+
+		return tokenModifiers;
+	}
+
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticTokensClient.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticTokensClient.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Broadcom, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Broadcom, Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.operations.semanticTokens;
+
+import static org.eclipse.lsp4e.internal.NullSafetyHelper.castNonNull;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.lsp4e.LSPEclipseUtils;
+import org.eclipse.lsp4e.LanguageServerWrapper;
+import org.eclipse.lsp4e.LanguageServers;
+import org.eclipse.lsp4e.LanguageServers.LanguageServerDocumentExecutor;
+import org.eclipse.lsp4j.SemanticTokens;
+import org.eclipse.lsp4j.SemanticTokensLegend;
+import org.eclipse.lsp4j.SemanticTokensParams;
+import org.eclipse.lsp4j.SemanticTokensWithRegistrationOptions;
+import org.eclipse.lsp4j.ServerCapabilities;
+
+public final class SemanticTokensClient {
+
+	public static final SemanticTokensClient DEFAULT = new SemanticTokensClient();
+
+	private SemanticTokensClient() {
+
+	}
+
+	public <T> CompletableFuture<Optional<T>> requestFullSemanticTokens(IDocument document, BiFunction<@Nullable SemanticTokensLegend, SemanticTokens, T> callback) {
+		LanguageServerDocumentExecutor executor = LanguageServers.forDocument(document)
+				.withFilter(serverCapabilities -> serverCapabilities.getSemanticTokensProvider() != null
+						&& LSPEclipseUtils.hasCapability(serverCapabilities.getSemanticTokensProvider().getFull()));
+
+		URI uri = castNonNull(LSPEclipseUtils.toUri(document));
+		final var semanticTokensParams = new SemanticTokensParams();
+		semanticTokensParams.setTextDocument(LSPEclipseUtils.toTextDocumentIdentifier(uri));
+
+		return executor //
+			.computeFirst((w, ls) -> ls.getTextDocumentService().semanticTokensFull(semanticTokensParams)
+					.thenApply(semanticTokens -> callback.apply(getSemanticTokensLegend(w), semanticTokens)));
+	}
+
+	// public for testing
+	public @Nullable SemanticTokensLegend getSemanticTokensLegend(final LanguageServerWrapper wrapper) {
+		ServerCapabilities serverCapabilities = wrapper.getServerCapabilities();
+		if (serverCapabilities != null) {
+			SemanticTokensWithRegistrationOptions semanticTokensProvider = serverCapabilities
+					.getSemanticTokensProvider();
+			if (semanticTokensProvider != null) {
+				return semanticTokensProvider.getLegend();
+			}
+		}
+		return null;
+	}
+
+}


### PR DESCRIPTION
Based on the latest addition of semantic tokens extension for Java editor the support is added for having semantic tokens from the language server in the Java editor.
There is a preference add to turn off semantic tokens support in the Java editor. The preference is defined but the UI is not and is expected to come from 3rd party plugins using this functionality (i.e. spring boot ls plugin) otherwise it's unclear where to fit this preference in the UI at the moment