### PR TITLE
docs: update repo URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## LSP4E Changelog and New and Noteworthy
 
-The [GitHub releases page](https://github.com/eclipse/lsp4e/releases) provides changelog and details on all releases.
+The [GitHub releases page](https://github.com/eclipse-lsp4e/lsp4e/releases) provides changelog and details on all releases.
 Older releases are listed below.
 
 ### 0.20.2
@@ -19,7 +19,7 @@ Among others:
 
 📅 Release Date: November 24th, 2021
 
-Bugfixes (including fix for regression [Issue #3 - Avoid error in compare editor](https://github.com/eclipse/lsp4e/issues/3)) and code improvements
+Bugfixes (including fix for regression [Issue #3 - Avoid error in compare editor](https://github.com/eclipse-lsp4e/lsp4e/issues/3)) and code improvements
 
 
 ### 0.20.0
@@ -76,7 +76,7 @@ Bugfixes (including fix for regression [Issue #3 - Avoid error in compare editor
 * Highlight.js is now being used for lsp4e's completion documentation. See [Bug 565496](https://bugs.eclipse.org/bugs/show_bug.cgi?id=565496)
 * LSP4E's format menu item has been relocated Generic Editor Source submenu
 * New icon for unit completion kind. See [Bug 567812 ](https://bugs.eclipse.org/bugs/show_bug.cgi?id=567812)
-* [CommandExecutor](org.eclipse.lsp4e/src/org/eclipse/lsp4e/command/CommandExecutor.java) has been updated with the improvements that were originally developed in WildWebDeveloper. Migrating those changes back to LSP4E makes these improvements available for all consumers of LSP4E.
+* [CommandExecutor](org.eclipse.lsp4e/src/org/eclipse-lsp4e/lsp4e/command/CommandExecutor.java) has been updated with the improvements that were originally developed in WildWebDeveloper. Migrating those changes back to LSP4E makes these improvements available for all consumers of LSP4E.
 
 See also the [Bugzilla issues](https://bugs.eclipse.org/bugs/buglist.cgi?product=lsp4e&target_milestone=0.17.0) for details of bug fixes and other items changed in this release.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Welcome to the Eclipse LSP4E contributor land, and thanks in advance for your help in making Eclipse LSP4E better and better!
 
-🏠 Official Eclipse LSP4E Git repo is [https://github.com/eclipse/lsp4e](https://github.com/eclipse/lsp4e) . (All other repositories, mirrors and so on are legacy repositories that should be removed at some point, so please don't use them!)
+🏠 Official Eclipse LSP4E Git repo is [https://github.com/eclipse-lsp4e/lsp4e](https://github.com/eclipse-lsp4e/lsp4e) . (All other repositories, mirrors and so on are legacy repositories that should be removed at some point, so please don't use them!)
 
 ## ⚖️ Legal and Eclipse Foundation terms
 
@@ -25,7 +25,7 @@ For more information, please see the Eclipse Committer Handbook:
 
 Eclipse LSP4E use mainly 2 channels for strategical and technical discussions
 
-* 🐞 View and report issues through uses GitHub Issues at https://github.com/eclipse/lsp4e/issues.
+* 🐞 View and report issues through uses GitHub Issues at https://github.com/eclipse-lsp4e/lsp4e/issues.
 * 📧 Join the lsp4e-dev@eclipse.org mailing-list to get in touch with other contributors about project organization and planning, and browse archive at 📜 [https://accounts.eclipse.org/mailing-list/lsp4e-dev](https://accounts.eclipse.org/mailing-list/lsp4e-dev)
 
 
@@ -118,7 +118,7 @@ The delta for version bumps are:
 
 ### ➕ Submit changes
 
-LSP4E only accepts contributions via GitHub Pull Requests against [https://github.com/eclipse/lsp4e](https://github.com/eclipse/lsp4e) repository.
+LSP4E only accepts contributions via GitHub Pull Requests against [https://github.com/eclipse-lsp4e/lsp4e](https://github.com/eclipse-lsp4e/lsp4e) repository.
 
 Before sending us a pull request, please ensure that:
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Eclipse LSP4E - Language Server Protocol client for Eclipse IDE
 
 [![Jenkins Tests](https://img.shields.io/jenkins/tests?jobUrl=https%3A%2F%2Fci.eclipse.org%2Flsp4e%2Fjob%2Flsp4e-github%2Fjob%2Fmain%2F&logo=jenkins&logoColor=white&label=Jenkins%20Tests)](https://ci.eclipse.org/lsp4e/job/lsp4e-github/job/main/)
-[![GitHub Actions](https://github.com/eclipse/eclipse-lsp4e/actions/workflows/build.yml/badge.svg)](https://github.com/eclipse-lsp4e/lsp4e/actions/workflows/build.yml)
-[![License](https://img.shields.io/github/license/eclipse/lsp4e.svg?color=blue)](LICENSE)
+[![GitHub Actions](https://github.com/eclipse-lsp4e/lsp4e/actions/workflows/build.yml/badge.svg)](https://github.com/eclipse-lsp4e/lsp4e/actions/workflows/build.yml)
+[![License](https://img.shields.io/github/license/eclipse-lsp4e/lsp4e.svg?color=blue)](LICENSE)
 
 [![Clone to Eclipse IDE](https://mickaelistria.github.io/redirctToEclipseIDECloneCommand/cloneToEclipseBadge.png)](https://mickaelistria.github.io/redirctToEclipseIDECloneCommand/redirect.html)
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServerWrapperTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServerWrapperTest.java
@@ -72,7 +72,7 @@ public class LanguageServerWrapperTest extends AbstractTestWithProject {
 
 	/**
 	 * Check if {@code isActive()} is correctly synchronized with  {@code stop()}
-	 * @see https://github.com/eclipse/lsp4e/pull/688
+	 * @see https://github.com/eclipse-lsp4e/lsp4e/pull/688
 	 */
 	@Test
 	public void testStartStopAndActive() throws CoreException, AssertionError, InterruptedException, ExecutionException {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/TokenTypeMapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/TokenTypeMapper.java
@@ -55,7 +55,7 @@ abstract class TokenTypeMapper implements Function<String, @Nullable IToken> {
 			}
 
 			// Do NOT fallback to default theme, as this may result in a deadlock!
-			// See https://github.com/eclipse/lsp4e/issues/1028
+			// See https://github.com/eclipse-lsp4e/lsp4e/issues/1028
 			// return TMUIPlugin.getThemeManager().getDefaultTheme().getToken(tokenType);
 			return null;
 		}


### PR DESCRIPTION
updates `https://github.com/eclipse/lsp4e` to `https://github.com/eclipse-lsp4e/lsp4e`