### PR TITLE
fix: Path matching in TextSelectionToIVariable does not work on Windows

### DIFF
--- a/org.eclipse.lsp4e.debug/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.debug/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Debug Adapter client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.debug;singleton:=true
 Bundle-Vendor: Eclipse LSP4E
-Bundle-Version: 0.15.13.qualifier
+Bundle-Version: 0.15.14.qualifier
 Bundle-Activator: org.eclipse.lsp4e.debug.DSPPlugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/breakpoints/TextSelectionToIVariable.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/breakpoints/TextSelectionToIVariable.java
@@ -10,6 +10,9 @@ package org.eclipse.lsp4e.debug.breakpoints;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.URI;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Paths;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
@@ -125,7 +128,15 @@ public class TextSelectionToIVariable implements IAdapterFactory {
 			final var uri = LSPEclipseUtils.toUri(document);
 			if (uri == null)
 				return false;
-			return Objects.equals(uri.getPath(), sourceElement);
+
+			final URI sourceUri;
+			try {
+				sourceUri = Paths.get(sourceElement).toUri();
+			} catch (InvalidPathException invalidPath) {
+				return false;
+			}
+
+			return Objects.equals(uri.getPath(), sourceUri.getPath());
 		}
 		return false;
 	}

--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/breakpoints/TextSelectionToIVariable.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/breakpoints/TextSelectionToIVariable.java
@@ -129,6 +129,8 @@ public class TextSelectionToIVariable implements IAdapterFactory {
 			if (uri == null)
 				return false;
 
+			// Convert sourceElement to a URI to normalize potential backslashes in the
+			// path. This can be necessary on Windows.
 			final URI sourceUri;
 			try {
 				sourceUri = Paths.get(sourceElement).toUri();


### PR DESCRIPTION
+ Convert sourceElement to URI before comparing paths
+ Bump point version of org.eclipse.lsp4e.debug