### PR TITLE
fix: Prevent LanguageServers.forProject().anyMatching() from blocking

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServersTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/LanguageServersTest.java
@@ -585,6 +585,28 @@ public class LanguageServersTest extends AbstractTestWithProject {
 	}
 
 	@Test
+	public void testAnyMatchingIsNonBlocking() throws Exception {
+		// test with no LS available
+		long start = System.currentTimeMillis();
+		assertFalse(LanguageServers.forProject(project).anyMatching());
+		long duration = System.currentTimeMillis() - start;
+		assertTrue("LanguageServers.anyMatching() took too long: " + duration + "ms", duration < 100);
+
+		// test with one slow LS available
+		MockLanguageServer.INSTANCE.setTimeToProceedQueries(5_000);
+		var testFile1 = createUniqueTestFile(project, "");
+		var editor1 = openEditor(testFile1);
+		start = System.currentTimeMillis();
+		try {
+			assertTrue(LanguageServers.forProject(project).anyMatching());
+			duration = System.currentTimeMillis() - start;
+			assertTrue("LanguageServers.anyMatching() took too long: " + duration + "ms", duration < 100);
+		} finally {
+			editor1.getSite().getPage().closeEditor(editor1, false);
+		}
+	}
+
+	@Test
 	public void testNoMatchingServers() throws Exception {
 		final var hoverResponse = new Hover(List.of(Either.forLeft("HoverContent")), new Range(new Position(0,  0), new Position(0, 10)));
 		MockLanguageServer.INSTANCE.setHover(hoverResponse);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -913,7 +913,8 @@ public class LanguageServerWrapper {
 	}
 
 	/**
-	 * Warning: this is a long running operation
+	 * <b>IMPORTANT:</b> If the server isn't yet initialized this method will be
+	 * blocking for up to 10 seconds!
 	 *
 	 * @return the server capabilities, or null if initialization job didn't
 	 *         complete


### PR DESCRIPTION
This PR addresses https://github.com/eclipse-lsp4e/lsp4e/issues/894

`LanguageServers.forProject(...).anyMatching()` may unexpectedly block for up to 10 seconds per matching language server.

The issue occurs because `LanguageServers.forProject(...).anyMatching()` internally calls `LanguageServiceAccessor.capabilitiesComply()`, which in turn invokes `LanguageServerWrapper.getServerCapabilities()`. This method waits up to 10 seconds for the server to initialize, causing potential delays.

This fix ensures non-blocking behavior by addressing the synchronous invocation chain.

---

The offending call chain is:
```py
org.eclipse.jface.text.TextViewerHoverManager.doPresentInformation() or
org.eclipse.ui.internal.views.markers.MarkersTreeViewer.doUpdateItem()
-> LSPCodeActionMarkerResolution.checkMarkerResolution()
   -> LanguageServerProjectExecutor.withCapability(ServerCapabilities::getCodeActionProvider)
        .anyMatching()
      -> LanguageServerProjectExecutor.getServers()
         -> LanguageServiceAccessor.getStartedWrappers()
            -> ...capabilitiesComply(ServerCapabilities::getCodeActionProvider)
               -> LanguageServerWrapper.getServerCapabilities()
                  -> ...getInitializedServer().get(10, TimeUnit.SECONDS);
```
