### PR TITLE
feat: support initial folding of license header

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/folding/FoldingTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/folding/FoldingTest.java
@@ -12,64 +12,99 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
-import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.test.utils.AbstractTest;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
+import org.eclipse.lsp4e.ui.FoldingPreferencePage;
 import org.eclipse.lsp4j.FoldingRange;
 import org.eclipse.lsp4j.FoldingRangeKind;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.tests.harness.util.DisplayHelper;
 import org.junit.Test;
 
 public class FoldingTest extends AbstractTest {
 
+	private static final int MAX_WAIT_FOR_FOLDING = 3_000;
+
 	private static final String CONTENT = """
+			/**
+			 * SPDX-License-Identifier: EPL-2.0
+			 */
 			import
 			import
 			import
+			/**
+			 * Some comment
+			 */
 			visible
 			""";
 
 	@Test
-	public void testImportsFoldedByDefaultEnabled() throws CoreException {
-		collapseImports(true);
+	public void testLicenseHeaderAutoFolding() throws CoreException {
+		configureCollapse(FoldingPreferencePage.PREF_AUTOFOLD_LICENSE_HEADERS_COMMENTS, true);
+		configureCollapse(FoldingPreferencePage.PREF_AUTOFOLD_IMPORT_STATEMENTS, false);
 		IEditorPart editor = createEditor();
 
 		// wait for folding to happen
-		DisplayHelper.waitAndAssertCondition(editor.getSite().getShell().getDisplay(),
-				() -> assertEquals("import\nvisible",
-						((StyledText) editor.getAdapter(Control.class)).getText().trim()));
+		TestUtils.waitForAndAssertCondition(MAX_WAIT_FOR_FOLDING, () -> assertEquals("""
+			/**
+			import
+			import
+			import
+			/**
+			 * Some comment
+			 */
+			visible""", ((StyledText) editor.getAdapter(Control.class)).getText().trim()));
 	}
 
 	@Test
-	public void testImportsFoldedByDefaultDisabled() throws CoreException {
-		collapseImports(false);
+	public void testImportsAutoFolding() throws CoreException {
+		configureCollapse(FoldingPreferencePage.PREF_AUTOFOLD_LICENSE_HEADERS_COMMENTS, false);
+		configureCollapse(FoldingPreferencePage.PREF_AUTOFOLD_IMPORT_STATEMENTS, true);
+
+		IEditorPart editor = createEditor();
+
+		// wait for folding to happen
+		TestUtils.waitForAndAssertCondition(MAX_WAIT_FOR_FOLDING, () -> assertEquals("""
+			/**
+			 * SPDX-License-Identifier: EPL-2.0
+			 */
+			import
+			/**
+			 * Some comment
+			 */
+			visible""", ((StyledText) editor.getAdapter(Control.class)).getText().trim()));
+	}
+
+	@Test
+	public void testAutoFoldingDisabled() throws CoreException {
+		configureCollapse(FoldingPreferencePage.PREF_AUTOFOLD_LICENSE_HEADERS_COMMENTS, false);
+		configureCollapse(FoldingPreferencePage.PREF_AUTOFOLD_IMPORT_STATEMENTS, false);
 		IEditorPart editor = createEditor();
 
 		// wait a few seconds before testing to ensure no folding happened
-		DisplayHelper.sleep(3000);
+		DisplayHelper.sleep(MAX_WAIT_FOR_FOLDING);
 		assertEquals(CONTENT, ((StyledText) editor.getAdapter(Control.class)).getText());
 	}
 
-	private IEditorPart createEditor() throws CoreException, PartInitException {
-		IFile file = TestUtils.createUniqueTestFile(null, CONTENT);
-		final var foldingRange = new FoldingRange(0, 2);
-		foldingRange.setKind(FoldingRangeKind.Imports);
-		MockLanguageServer.INSTANCE.setFoldingRanges(List.of(foldingRange));
-		IEditorPart editor = TestUtils.openEditor(file);
-		return editor;
+	private IEditorPart createEditor() throws CoreException {
+		final var foldingRangeLicense = new FoldingRange(0, 2);
+		foldingRangeLicense.setKind(FoldingRangeKind.Comment);
+		final var foldingRangeImport = new FoldingRange(3, 5);
+		foldingRangeImport.setKind(FoldingRangeKind.Imports);
+		MockLanguageServer.INSTANCE.setFoldingRanges(List.of(foldingRangeLicense, foldingRangeImport));
+
+		return TestUtils.openEditor(TestUtils.createUniqueTestFile(null, CONTENT));
 	}
 
-	private void collapseImports(boolean collapseImports) {
+	private void configureCollapse(String type, boolean collapse) {
 		IPreferenceStore store = LanguageServerPlugin.getDefault().getPreferenceStore();
-		store.setValue("foldingReconcilingStrategy.collapseImports", collapseImports); //$NON-NLS-1$
+		store.setValue(type, collapse);
+		store.setValue(FoldingPreferencePage.PREF_AUTOFOLD_IMPORT_STATEMENTS, collapse); //$NON-NLS-1$
 	}
-
 }

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/TestUtils.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/utils/TestUtils.java
@@ -297,6 +297,24 @@ public class TestUtils {
 		return null;
 	}
 
+	public static void waitForAndAssertCondition(int timeout_ms, Runnable condition) {
+		waitForAndAssertCondition("Condition not met within expected time.", timeout_ms, condition);
+	}
+
+	public static void waitForAndAssertCondition(int timeout_ms, Display display, Runnable condition) {
+		waitForAndAssertCondition("Condition not met within expected time.", timeout_ms, display, () -> {
+			condition.run();
+			return true;
+		});
+	}
+
+	public static void waitForAndAssertCondition(String errorMessage, int timeout_ms, Runnable condition) {
+		waitForAndAssertCondition(errorMessage, timeout_ms, UI.getDisplay(), () -> {
+			condition.run();
+			return true;
+		});
+	}
+
 	public static void waitForAndAssertCondition(int timeout_ms, Condition condition) {
 		waitForAndAssertCondition("Condition not met within expected time.", timeout_ms, condition);
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/FoldingPreferencePage.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/ui/FoldingPreferencePage.java
@@ -26,6 +26,7 @@ public class FoldingPreferencePage extends FieldEditorPreferencePage implements 
 
 	public static final String PREF_FOLDING_ENABLED = "foldingReconcilingStrategy.enabled"; //$NON-NLS-1$
 	public static final String PREF_AUTOFOLD_COMMENTS = "foldingReconcilingStrategy.collapseComments"; //$NON-NLS-1$
+	public static final String PREF_AUTOFOLD_LICENSE_HEADERS_COMMENTS = "foldingReconcilingStrategy.collapseLicenseHeaders"; //$NON-NLS-1$
 	public static final String PREF_AUTOFOLD_REGIONS = "foldingReconcilingStrategy.collapseRegions"; //$NON-NLS-1$
 	public static final String PREF_AUTOFOLD_IMPORT_STATEMENTS = "foldingReconcilingStrategy.collapseImports"; //$NON-NLS-1$
 
@@ -35,6 +36,7 @@ public class FoldingPreferencePage extends FieldEditorPreferencePage implements 
 			final var store = LanguageServerPlugin.getDefault().getPreferenceStore();
 			store.setDefault(PREF_FOLDING_ENABLED, true);
 			store.setDefault(PREF_AUTOFOLD_COMMENTS, false);
+			store.setDefault(PREF_AUTOFOLD_LICENSE_HEADERS_COMMENTS, false);
 			store.setDefault(PREF_AUTOFOLD_REGIONS, false);
 			store.setDefault(PREF_AUTOFOLD_IMPORT_STATEMENTS, false);
 		}
@@ -47,32 +49,61 @@ public class FoldingPreferencePage extends FieldEditorPreferencePage implements 
 
 	@Override
 	public void createFieldEditors() {
-		Composite parent = getFieldEditorParent();
+		final Composite parent = getFieldEditorParent();
 
-		// Add check boxes
-		addField(new BooleanFieldEditor( //
+		/*
+		 * check box to globally enable/disable folding
+		 */
+		final var foldingEnabled = new BooleanFieldEditor( //
 				PREF_FOLDING_ENABLED, //
 				"Enable folding", //$NON-NLS-1$
-				parent));
+				parent);
+		addField(foldingEnabled);
 
-		// Add a label before the field editors
 		final var label = new Label(parent, SWT.NONE);
-		label.setText("Initially fold these elements:"); //$NON-NLS-1$
+		label.setText("\nInitially fold these elements:"); //$NON-NLS-1$
 		label.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 
-		// Add check boxes
-		addField(new BooleanFieldEditor( //
+		/*
+		 * check boxes to control auto-folding
+		 */
+		final var autoFoldComments = new BooleanFieldEditor( //
 				PREF_AUTOFOLD_COMMENTS, //
 				"Comments", //$NON-NLS-1$
-				parent));
-		addField(new BooleanFieldEditor( //
-				PREF_AUTOFOLD_COMMENTS, //
+				parent);
+		addField(autoFoldComments);
+
+		final var autoFoldLicenseHeaders = new BooleanFieldEditor( //
+				PREF_AUTOFOLD_LICENSE_HEADERS_COMMENTS, //
+				"License Header Comments", //$NON-NLS-1$
+				parent);
+		addField(autoFoldLicenseHeaders);
+
+		final var autoFoldRegions = new BooleanFieldEditor( //
+				PREF_AUTOFOLD_REGIONS, //
 				"Folding Regions", //$NON-NLS-1$
-				parent));
-		addField(new BooleanFieldEditor( //
+				parent);
+		addField(autoFoldRegions);
+
+		final var autoFoldImports = new BooleanFieldEditor( //
 				PREF_AUTOFOLD_IMPORT_STATEMENTS, //
 				"Import statements", //$NON-NLS-1$
-				parent));
+				parent);
+		addField(autoFoldImports);
+
+		/*
+		 * update editor states
+		 */
+		final Runnable updateEditorStates = () -> {
+			autoFoldComments.setEnabled(foldingEnabled.getBooleanValue(), parent);
+			autoFoldLicenseHeaders.setEnabled(foldingEnabled.getBooleanValue() && !autoFoldComments.getBooleanValue(),
+					parent);
+			autoFoldRegions.setEnabled(foldingEnabled.getBooleanValue(), parent);
+			autoFoldImports.setEnabled(foldingEnabled.getBooleanValue(), parent);
+		};
+		foldingEnabled.getDescriptionControl(parent).addListener(SWT.Selection, event -> updateEditorStates.run());
+		autoFoldComments.getDescriptionControl(parent).addListener(SWT.Selection, event -> updateEditorStates.run());
+		UI.getDisplay().asyncExec(updateEditorStates);
 	}
 
 	@Override


### PR DESCRIPTION
This PR addresses https://github.com/eclipse-lsp4e/lsp4e/issues/884 by adding a new folding option to automatically fold license headers on initial opening of an editor.

![image](https://github.com/user-attachments/assets/eda5b113-8c0c-4f68-a776-3ec1bb74f611)

If the first foldable comment of a file a license header is determined using a regex `(?i)(copyright|licensed under|all rights reserved|SPDX-License-Identifier)`

The behaviour is different to Eclipse JDT which has an option to generally fold all header comments:
![image](https://github.com/user-attachments/assets/cc1b3872-8f9c-4c27-9b16-35c06075de1b)
