### PR TITLE
Ignoring failures when checking for hyperlinks

### DIFF
--- a/org.eclipse.lsp4e/.project
+++ b/org.eclipse.lsp4e/.project
@@ -30,10 +30,16 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.whitesource.eclipse.plugin.WSbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.whitesource.eclipse.plugin.WSNature</nature>
 	</natures>
 </projectDescription>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/OpenDeclarationHyperlinkDetector.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/declaration/OpenDeclarationHyperlinkDetector.java
@@ -13,15 +13,6 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.operations.declaration;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.text.BadLocationException;
@@ -42,6 +33,15 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class OpenDeclarationHyperlinkDetector extends AbstractHyperlinkDetector {
 
@@ -68,7 +68,7 @@ public class OpenDeclarationHyperlinkDetector extends AbstractHyperlinkDetector 
 				.collectAll(ls -> ls.getTextDocumentService().typeDefinition(LSPEclipseUtils.toTypeDefinitionParams(params)).thenApply(l -> Pair.of(Messages.typeDefinitionHyperlinkLabel, l)));
 			var implementations = LanguageServers.forDocument(document).withCapability(ServerCapabilities::getImplementationProvider)
 				.collectAll(ls -> ls.getTextDocumentService().implementation(LSPEclipseUtils.toImplementationParams(params)).thenApply(l -> Pair.of(Messages.implementationHyperlinkLabel, l)));
-			LanguageServers.addAll(LanguageServers.addAll(LanguageServers.addAll(definitions, declarations), typeDefinitions), implementations)
+			LanguageServers.addAllSuccessful(definitions, declarations, typeDefinitions, implementations)
 				.get(800, TimeUnit.MILLISECONDS)
 				.stream().flatMap(locations -> toHyperlinks(document, region, locations.first(), locations.second()).stream())
 				.forEach(link -> allLinks.putIfAbsent(link.getLocation(), link));


### PR DESCRIPTION
Adding LanguageServers.addAllSuccessful as an alternative to LanguageServers.addAll so that exceptions from one of the requests being combined can be ignored. Then using this new method in OpenDeclarationHyperlinkDetector when combining the results from definitions, declarations, typeDefinitions, and implementions because some LSPs return errors instead of empty lists for some of these calls. Instead, we combine only the successful results when building the list of hyperlinks, ignoring the errors.

This should resolve https://github.com/eclipse-lsp4e/lsp4e/issues/1169