### PR TITLE
chore: remove deprecated LSPDiagnosticsToMarkers(IProject, String) ctor

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/diagnostics/LSPDiagnosticsToMarkers.java
@@ -24,7 +24,6 @@ import java.util.function.Consumer;
 import org.eclipse.core.filebuffers.FileBuffers;
 import org.eclipse.core.filebuffers.LocationKind;
 import org.eclipse.core.resources.IMarker;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.CoreException;
@@ -80,18 +79,6 @@ public class LSPDiagnosticsToMarkers implements Consumer<PublishDiagnosticsParam
 
 	public LSPDiagnosticsToMarkers(String serverId) {
 		this(serverId, null, null);
-	}
-
-	/**
-	 *
-	 * @param project
-	 * @param serverId
-	 *            ignored
-	 * @deprecated
-	 */
-	@Deprecated
-	public LSPDiagnosticsToMarkers(IProject project, String serverId) {
-		this(serverId);
 	}
 
 	@Override


### PR DESCRIPTION
This constructor has been deprecated in [2017](https://github.com/eclipse-lsp4e/lsp4e/commit/57af43039f3471e25b95477604e45e87ac614966#diff-60fa8d8d842d7875d0697f9442ff38ebd80505a3478fad605accf522fe27cadb) and is not used in any other dependend project on GitHub.