### PR TITLE
[#1194] make process accessible for subclasses

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.18.16.qualifier
+Bundle-Version: 0.18.17.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.18.16-SNAPSHOT</version>
+	<version>0.18.17-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/server/ProcessStreamConnectionProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/server/ProcessStreamConnectionProvider.java
@@ -112,6 +112,10 @@ public abstract class ProcessStreamConnectionProvider implements StreamConnectio
 		return null;
 	}
 
+	protected @Nullable Process getProcess() {
+		return process;
+	}
+
 	protected @Nullable List<String> getCommands() {
 		return commands;
 	}


### PR DESCRIPTION
...to allow onExit operations (e.g. to close streams of piped stderr from process) 

fixes #1194