### PR TITLE
DAPWatchExpression: avoid 'Unexpected null value' error when editing expressions

### DIFF
--- a/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/presentation/DAPWatchExpression.java
+++ b/org.eclipse.lsp4e.debug/src/org/eclipse/lsp4e/debug/presentation/DAPWatchExpression.java
@@ -32,10 +32,19 @@ public class DAPWatchExpression implements IWatchExpressionDelegate {
 		if (context.getDebugTarget() instanceof DSPDebugTarget dapDebugger) {
 			final var args = new EvaluateArguments();
 			args.setExpression(expression);
-			DSPStackFrame frame = castNonNull(Adapters.adapt(context, DSPStackFrame.class));
-			args.setFrameId(frame.getFrameId());
-			dapDebugger.getDebugProtocolServer().evaluate(args).thenAccept(
-					res -> listener.watchEvaluationFinished(createWatchResult(dapDebugger, expression, res)));
+
+			@Nullable
+			DSPStackFrame dspStackFrame = Adapters.adapt(context, DSPStackFrame.class);
+			if (dspStackFrame != null) {
+				DSPStackFrame frame = castNonNull(dspStackFrame);
+				args.setFrameId(frame.getFrameId());
+				dapDebugger.getDebugProtocolServer().evaluate(args).thenAccept(
+						res -> listener.watchEvaluationFinished(createWatchResult(dapDebugger, expression, res)));
+			} else {
+				EvaluateResponse res = new EvaluateResponse();
+				res.setResult("");
+				listener.watchEvaluationFinished(createWatchResult(dapDebugger, expression, res));
+			}
 		}
 	}
 


### PR DESCRIPTION
This is a proposed fix for #1199. I add a `null` check to the result of the `adapt` call, as this adaptation may return `null` if you try to edit or re-evaluate the expression after the program has finished running (e.g. between repeated debugging sessions of the same program).