### PR TITLE
refact: cleanup of CompletionProposalTools.getScoreOfFilterMatch

### DIFF
--- a/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for language server bundle (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.test;singleton:=true
-Bundle-Version: 0.15.22.qualifier
+Bundle-Version: 0.15.23.qualifier
 Fragment-Host: org.eclipse.lsp4e
 Bundle-Vendor: Eclipse LSP4E
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.lsp4e.test/pom.xml
+++ b/org.eclipse.lsp4e.test/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.15.22-SNAPSHOT</version>
+	<version>0.15.23-SNAPSHOT</version>
 
 	<properties>
 		<os-jvm-flags /> <!-- for the default case -->

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/ScoreOfFilterMatchTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/ScoreOfFilterMatchTest.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Vegard IT GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Sebastian Thomschke (Vegard IT GmbH) - initial implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.test.completion;
+
+import static org.junit.Assert.*;
+
+import java.util.Random;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.lsp4e.operations.completion.CompletionProposalTools;
+import org.junit.Test;
+
+/**
+ * Test cases for {@link CompletionProposalTools#getScoreOfFilterMatch(String, String)}
+ */
+public class ScoreOfFilterMatchTest {
+	private static final Random RANDOM = new Random();
+
+	private static String generateRandomString(final int maxLength) {
+		final var length = RANDOM.nextInt(maxLength + 1);
+		if (length == 0)
+			return "";
+		var chars = "abcdefghijklmnopqrstuvwxyzäöüß";
+		chars = "_" + chars + chars.toUpperCase();
+		final var sb = new StringBuilder(length);
+		for (int i = 0; i < length; i++) {
+			sb.append(chars.charAt(RANDOM.nextInt(chars.length())));
+		}
+		return sb.toString();
+	}
+
+	@Test
+	public void testCaseInsensitivity() {
+		final var documentFilter = "Example";
+		final var completionFilter = "eXaMpLe";
+		final int expectedScore = 0;
+		final int actualScore = CompletionProposalTools.getScoreOfFilterMatch(documentFilter, completionFilter);
+		assertEquals("The score should be 0 for case-insensitive matches.", expectedScore, actualScore);
+	}
+
+	@Test
+	public void testEmptyCompletionFilter() {
+		final var documentFilter = "example";
+		final var completionFilter = "";
+		final int expectedScore = -1;
+		final int actualScore = CompletionProposalTools.getScoreOfFilterMatch(documentFilter, completionFilter);
+		assertEquals("The score should be -1 for an empty completionFilter.", expectedScore, actualScore);
+	}
+
+	@Test
+	public void testEmptyDocumentFilter() {
+		final var documentFilter = "";
+		final var completionFilter = "example";
+		final int expectedScore = 0;
+		final int actualScore = CompletionProposalTools.getScoreOfFilterMatch(documentFilter, completionFilter);
+		assertEquals("The score should be 0 for an empty documentFilter.", expectedScore, actualScore);
+	}
+
+	/**
+	 * Test case for https://github.com/eclipse-lsp4e/lsp4e/issues/1132
+	 */
+	@Test
+	public void testRandomFilters() {
+		final int testCases = 50_000; // Number of random test cases to try
+		final int timeoutMS = 3; // Timeout threshold for detecting infinite loops
+
+		final var executor = Executors.newSingleThreadExecutor();
+
+		for (int i = 0; i < testCases; i++) {
+			final var commonPrefix = generateRandomString(2); // String with length of 0-2 chars
+			final var documentFilter = commonPrefix + generateRandomString(5);
+			final var completionFilter = commonPrefix + generateRandomString(15);
+
+			final var future = executor
+					.submit(() -> CompletionProposalTools.getScoreOfFilterMatch(documentFilter, completionFilter));
+
+			try {
+				future.get(timeoutMS, TimeUnit.SECONDS);
+			} catch (final TimeoutException e) {
+				future.cancel(true); // Interrupt stuck execution
+				fail("Possible infinite loop detected in getScoreOfFilterMatch with inputs: " + "documentFilter='"
+						+ documentFilter + "', completionFilter='" + completionFilter + "'");
+			} catch (Exception e) {
+				fail("Unexpected exception: " + e.getMessage());
+			}
+		}
+
+		executor.shutdown();
+	}
+
+	@Test
+	public void testExactMatch() {
+		final var documentFilter = "example";
+		final var completionFilter = "example";
+		final int expectedScore = 0;
+		final int actualScore = CompletionProposalTools.getScoreOfFilterMatch(documentFilter, completionFilter);
+		assertEquals("The score should be 0 for exact matches.", expectedScore, actualScore);
+	}
+
+	@Test
+	public void testNoMatch() {
+		final var documentFilter = "foo";
+		final var completionFilter = "example";
+		final int expectedScore = -1;
+		final int actualScore = CompletionProposalTools.getScoreOfFilterMatch(documentFilter, completionFilter);
+		assertEquals("The score should be -1 when there's no match.", expectedScore, actualScore);
+	}
+
+	@Test
+	public void testPrefixMatch() {
+		final var documentFilter = "ex";
+		final var completionFilter = "example";
+		final int expectedScore = 0;
+		final int actualScore = CompletionProposalTools.getScoreOfFilterMatch(documentFilter, completionFilter);
+		assertEquals("The score should be 0 when documentFilter is a prefix.", expectedScore, actualScore);
+	}
+
+	@Test
+	public void testScatteredMatch() {
+		final var documentFilter = "eap";
+		final var completionFilter = "example";
+		final int expectedScore = 6;
+		final int actualScore = CompletionProposalTools.getScoreOfFilterMatch(documentFilter, completionFilter);
+		assertEquals("The score should account for scattered characters.", expectedScore, actualScore);
+	}
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/CompletionProposalTools.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/CompletionProposalTools.java
@@ -145,17 +145,17 @@ public final class CompletionProposalTools {
 	 * @return score of the match where the lower the number, the better the score
 	 *         and -1 mean there was no match
 	 */
-	public static int getScoreOfFilterMatch(String documentFilter, String completionFilter) {
-		documentFilter = documentFilter.toLowerCase();
-		completionFilter = completionFilter.toLowerCase();
-		return getScoreOfFilterMatchHelper(0, documentFilter, completionFilter);
+	public static int getScoreOfFilterMatch(final String documentFilter, final String completionFilter) {
+		return getScoreOfFilterMatchHelper(0, documentFilter.toLowerCase(), completionFilter.toLowerCase());
 	}
 
-	private static int getScoreOfFilterMatchHelper(int prefixLength, String documentFilter, String completionFilter) {
+	private static int getScoreOfFilterMatchHelper(final int prefixLength, final String documentFilter,
+			final String completionFilter) {
 		if (documentFilter.isEmpty()) {
 			return 0;
 		}
-		char searchChar = documentFilter.charAt(0);
+
+		final char searchChar = documentFilter.charAt(0);
 		int i = completionFilter.indexOf(searchChar);
 		if (i == -1) {
 			return -1;
@@ -166,17 +166,10 @@ public final class CompletionProposalTools {
 			return i + prefixLength;
 		}
 
-		int matchLength = commonPrefixLength(documentFilter, completionFilter.substring(i));
-		if (matchLength == documentFilterLength) {
-			return i + prefixLength;
-		}
-		int bestScore = i + getScoreOfFilterMatchHelper(prefixLength + i + matchLength,
-				documentFilter.substring(matchLength),
-				completionFilter.substring(i + matchLength));
+		int bestScore = Integer.MAX_VALUE;
 
-		i = completionFilter.indexOf(searchChar, i + 1);
 		while (i != -1) {
-			matchLength = commonPrefixLength(documentFilter, completionFilter.substring(i));
+			final int matchLength = commonPrefixLength(documentFilter, completionFilter.substring(i));
 			if (matchLength == documentFilterLength) {
 				return i + prefixLength;
 			}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/CompletionProposalTools.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/CompletionProposalTools.java
@@ -166,7 +166,7 @@ public final class CompletionProposalTools {
 			return i + prefixLength;
 		}
 
-		int matchLength = lengthOfPrefixMatch(documentFilter, completionFilter.substring(i));
+		int matchLength = commonPrefixLength(documentFilter, completionFilter.substring(i));
 		if (matchLength == documentFilterLength) {
 			return i + prefixLength;
 		}
@@ -176,7 +176,7 @@ public final class CompletionProposalTools {
 
 		i = completionFilter.indexOf(searchChar, i + 1);
 		while (i != -1) {
-			matchLength = lengthOfPrefixMatch(documentFilter, completionFilter.substring(i));
+			matchLength = commonPrefixLength(documentFilter, completionFilter.substring(i));
 			if (matchLength == documentFilterLength) {
 				return i + prefixLength;
 			}
@@ -192,10 +192,10 @@ public final class CompletionProposalTools {
 		return prefixLength + bestScore;
 	}
 
-	private static int lengthOfPrefixMatch(String first, String second) {
+	private static int commonPrefixLength(final String first, final String second) {
 		int i;
-		final var maxLength = Math.min(first.length(), second.length());
-		for (i = 0; i < maxLength; i++) {
+		final var maxCommonLength = Math.min(first.length(), second.length());
+		for (i = 0; i < maxCommonLength; i++) {
 			if (first.charAt(i) != second.charAt(i))
 				break;
 		}


### PR DESCRIPTION
This PR performs a minor refactoring of CompletionProposalTools.getScoreOfFilterMatch()

It also adds a dedicated JUnit test class with test cases to verify functionality of getScoreOfFilterMatch.

The test case `testRandomFilters()` creates several thousands of random filters to proof that the endless loop reported by https://github.com/eclipse-lsp4e/lsp4e/issues/1132 is not caused by `getScoreOfFilterMatch` itself.