### PR TITLE
Consider viewer's visible region when preparing underline StyleRange[]. Fixes #1220

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/documentLink/DocumentLinkReconcilingTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/documentLink/DocumentLinkReconcilingTest.java
@@ -1,0 +1,189 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Jozef Tomek - initial implementation
+ *******************************************************************************/
+
+package org.eclipse.lsp4e.test.documentLink;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.Region;
+import org.eclipse.jface.text.TextPresentation;
+import org.eclipse.jface.text.TextViewer;
+import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
+import org.eclipse.lsp4e.test.utils.TestUtils;
+import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
+import org.eclipse.lsp4j.DocumentLink;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.swt.custom.StyleRange;
+import org.eclipse.swt.graphics.Color;
+import org.junit.Test;
+
+public class DocumentLinkReconcilingTest extends AbstractTestWithProject {
+	
+	private static final String CONTENT = """
+				1st_line #LINK1 1st_line
+				2nd_line #LINK2_START
+				#LINK2_END 3rd_line #LINK3 3rd_line
+				4th_line #LINK4 4th_line
+				5th_line #LINK5_START_#LINK5_END
+				6th_line #LINK6""";
+	
+	private static final List<DocumentLink> CONTENT_LINKS = List.of(
+			new DocumentLink(new Range(new Position(0, 9), new Position(0, 15)), "file://link1"),
+			new DocumentLink(new Range(new Position(1, 9), new Position(2, 10)), "file://link2"),
+			new DocumentLink(new Range(new Position(2, 20), new Position(2, 26)), "file://link3"),
+			new DocumentLink(new Range(new Position(3, 9), new Position(3, 15)), "file://link4"),
+			new DocumentLink(new Range(new Position(4, 9), new Position(4, 32)), "file://link5"),
+			new DocumentLink(new Range(new Position(5, 9), new Position(5, 15)), "file://link6"));
+	
+	public static final Color COLOR_1ST_LINE = new Color(255, 0, 0);
+	public static final Color COLOR_2ND_LINE = new Color(0, 255, 0);
+	public static final Color COLOR_3RD_LINE = new Color(0, 0, 255);
+	public static final Color COLOR_4TH_LINE = new Color(255, 255, 0);
+	public static final Color COLOR_5TH_LINE = new Color(0, 255, 255);
+	public static final Color COLOR_6TH_LINE = new Color(255, 0, 255);
+	
+	private List<TextPresentation> textPresentations = new ArrayList<>(4);
+	
+	@Test
+	public void testFullDocumentLinkReconciling() throws Exception {
+		MockLanguageServer.INSTANCE.setDocumentLinks(CONTENT_LINKS);
+
+		TextViewer viewer = (TextViewer) TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, CONTENT));
+		IDocument document = viewer.getDocument();
+		viewer.getTextWidget().setStyleRanges(new StyleRange[] {
+				textStyle(0, 25, COLOR_1ST_LINE), // whole 1st line
+				textStyle(25, 22, COLOR_2ND_LINE), // whole 2nd line
+				textStyle(47, 36, COLOR_3RD_LINE), // whole 3rd line
+				textStyle(83, 25, COLOR_4TH_LINE), // whole 4th line
+				textStyle(108, 33, COLOR_5TH_LINE), // whole 5th line
+				textStyle(141, 15, COLOR_6TH_LINE) // whole 6th line
+		});
+		viewer.addTextPresentationListener(this::textPresentationListener);
+		
+		TestUtils.waitForAndAssertCondition(1_000, () -> textPresentations.size() == 6);
+		
+		assertEquals(linkRegion(CONTENT_LINKS.get(0), document), textPresentations.get(0).getExtent());
+		assertEquals(linkRegion(CONTENT_LINKS.get(1), document), textPresentations.get(1).getExtent());
+		assertEquals(linkRegion(CONTENT_LINKS.get(2), document), textPresentations.get(2).getExtent());
+		assertEquals(linkRegion(CONTENT_LINKS.get(3), document), textPresentations.get(3).getExtent());
+		assertEquals(linkRegion(CONTENT_LINKS.get(4), document), textPresentations.get(4).getExtent());
+		assertEquals(linkRegion(CONTENT_LINKS.get(5), document), textPresentations.get(5).getExtent());
+		
+		var styles = viewer.getTextWidget().getStyleRanges();
+		
+		assertEquals(17, styles.length);
+		
+		var pos = 0;
+		var length = 0;
+		assertEquals(textStyle(pos, length = 9, COLOR_1ST_LINE), styles[0]);
+		assertEquals(linkStyle(pos += length, length = 6, COLOR_1ST_LINE), styles[1]);
+		assertEquals(textStyle(pos += length, length = 9 + 1, COLOR_1ST_LINE), styles[2]); // also new line char
+		
+		assertEquals(textStyle(pos += length, length = 9, COLOR_2ND_LINE), styles[3]);
+		assertEquals(linkStyle(pos += length, length = 12 + 1, COLOR_2ND_LINE), styles[4]); // also new line char
+		
+		assertEquals(linkStyle(pos += length, length = 10, COLOR_3RD_LINE), styles[5]);
+		assertEquals(textStyle(pos += length, length = 10, COLOR_3RD_LINE), styles[6]);
+		assertEquals(linkStyle(pos += length, length = 6, COLOR_3RD_LINE), styles[7]);
+		assertEquals(textStyle(pos += length, length = 9 + 1, COLOR_3RD_LINE), styles[8]); // also new line char
+		
+		assertEquals(textStyle(pos += length, length = 9, COLOR_4TH_LINE), styles[9]);
+		assertEquals(linkStyle(pos += length, length = 6, COLOR_4TH_LINE), styles[10]);
+		assertEquals(textStyle(pos += length, length = 9 + 1, COLOR_4TH_LINE), styles[11]); // also new line char
+		
+		assertEquals(textStyle(pos += length, length = 9, COLOR_5TH_LINE), styles[12]);
+		assertEquals(linkStyle(pos += length, length = 23, COLOR_5TH_LINE), styles[13]);
+		assertEquals(textStyle(pos += length, length = 1, COLOR_5TH_LINE), styles[14]); // new line char
+
+		assertEquals(textStyle(pos += length, length = 9, COLOR_6TH_LINE), styles[15]);
+		assertEquals(linkStyle(pos += length, length = 6, COLOR_6TH_LINE), styles[16]);
+	}
+
+	@Test
+	public void testClippedDocumentLinkReconciling() throws Exception {
+		MockLanguageServer.INSTANCE.setDocumentLinks(CONTENT_LINKS);
+		
+		TextViewer viewer = (TextViewer) TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, CONTENT));
+		IDocument document = viewer.getDocument();
+		int thirdLineStart = document.getLineOffset(2);
+		int untilMiddleOfLink5 = document.getLength() - thirdLineStart - document.getLineLength(5) - 1 - 11; 
+		// set visible region to 3rd + 4th + half of 5th line - link1 and link6 are out of visible region completely
+		// this triggers reconciliation by LSPDocumentLinkPresentationReconcilingStrategy
+		viewer.setVisibleRegion(
+				thirdLineStart, // TextViewer would align start of visible region to start of the line anyway
+				untilMiddleOfLink5);
+		viewer.getTextWidget().setStyleRanges(new StyleRange[] {
+				textStyle(0, 36, COLOR_3RD_LINE), // whole 3rd line
+				textStyle(36, 25, COLOR_4TH_LINE), // whole 4th line
+				textStyle(61, 21, COLOR_5TH_LINE) // whole last displayed line - visible part of 5th line
+		});
+		viewer.addTextPresentationListener(this::textPresentationListener);
+		
+		TestUtils.waitForAndAssertCondition(1_000, () -> textPresentations.size() == 6);
+		
+		assertEquals(linkRegion(CONTENT_LINKS.get(0), document), textPresentations.get(0).getExtent());
+		assertEquals(linkRegion(CONTENT_LINKS.get(1), document), textPresentations.get(1).getExtent());
+		assertEquals(linkRegion(CONTENT_LINKS.get(2), document), textPresentations.get(2).getExtent());
+		assertEquals(linkRegion(CONTENT_LINKS.get(3), document), textPresentations.get(3).getExtent());
+		assertEquals(linkRegion(CONTENT_LINKS.get(4), document), textPresentations.get(4).getExtent());
+		assertEquals(linkRegion(CONTENT_LINKS.get(5), document), textPresentations.get(5).getExtent());
+		
+		var styles = viewer.getTextWidget().getStyleRanges();
+		
+		assertEquals(9, styles.length);
+		
+		var pos = 0;
+		var length = 0;
+		assertEquals(linkStyle(pos, length = 10, COLOR_3RD_LINE), styles[0]);
+		assertEquals(textStyle(pos += length, length = 10, COLOR_3RD_LINE), styles[1]);
+		assertEquals(linkStyle(pos += length, length = 6, COLOR_3RD_LINE), styles[2]);
+		assertEquals(textStyle(pos += length, length = 9 + 1, COLOR_3RD_LINE), styles[3]); // also new line char
+		
+		assertEquals(textStyle(pos += length, length = 9, COLOR_4TH_LINE), styles[4]);
+		assertEquals(linkStyle(pos += length, length = 6, COLOR_4TH_LINE), styles[5]);
+		assertEquals(textStyle(pos += length, length = 9 + 1, COLOR_4TH_LINE), styles[6]); // also new line char
+		
+		assertEquals(textStyle(pos += length, length = 9, COLOR_5TH_LINE), styles[7]);
+		assertEquals(linkStyle(pos += length, length = 12, COLOR_5TH_LINE), styles[8]);
+	}
+	
+	private StyleRange textStyle(int start, int length, Color backgroundColor ) {
+		return new StyleRange(start, length, null, backgroundColor);
+	}
+	
+	private StyleRange linkStyle(int start, int length, Color backgroundColor ) {
+		var retVal = new StyleRange(start, length, null, backgroundColor);
+		retVal.underline = true;
+		return retVal;
+	}
+
+	private Region linkRegion(DocumentLink link, IDocument document) throws BadLocationException {
+		var start = link.getRange().getStart();
+		var end = link.getRange().getEnd();
+		int startOffset = document.getLineOffset(start.getLine()) + start.getCharacter();
+		return new Region(startOffset, (document.getLineOffset(end.getLine()) + end.getCharacter()) - startOffset);
+	}
+
+	private void textPresentationListener(TextPresentation textPresentation) {
+		textPresentations.add(textPresentation);
+	}
+}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/documentLink/DocumentLinkReconcilingTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/documentLink/DocumentLinkReconcilingTest.java
@@ -26,6 +26,8 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.TextPresentation;
 import org.eclipse.jface.text.TextViewer;
+import org.eclipse.jface.text.source.projection.ProjectionAnnotation;
+import org.eclipse.jface.text.source.projection.ProjectionViewer;
 import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
@@ -42,24 +44,30 @@ public class DocumentLinkReconcilingTest extends AbstractTestWithProject {
 				1st_line #LINK1 1st_line
 				2nd_line #LINK2_START
 				#LINK2_END 3rd_line #LINK3 3rd_line
-				4th_line #LINK4 4th_line
+				#LINK4
 				5th_line #LINK5_START_#LINK5_END
-				6th_line #LINK6""";
+				#LINK6_START
+				#LINK6_END
+				8th_line #LINK7 8th_line""";
 	
 	private static final List<DocumentLink> CONTENT_LINKS = List.of(
 			new DocumentLink(new Range(new Position(0, 9), new Position(0, 15)), "file://link1"),
 			new DocumentLink(new Range(new Position(1, 9), new Position(2, 10)), "file://link2"),
 			new DocumentLink(new Range(new Position(2, 20), new Position(2, 26)), "file://link3"),
-			new DocumentLink(new Range(new Position(3, 9), new Position(3, 15)), "file://link4"),
+			new DocumentLink(new Range(new Position(3, 0), new Position(3, 6)), "file://link4"),
 			new DocumentLink(new Range(new Position(4, 9), new Position(4, 32)), "file://link5"),
-			new DocumentLink(new Range(new Position(5, 9), new Position(5, 15)), "file://link6"));
+			new DocumentLink(new Range(new Position(5, 0), new Position(6, 10)), "file://link6"),
+			new DocumentLink(new Range(new Position(7, 9), new Position(7, 15)), "file://link7")
+			);
 	
 	public static final Color COLOR_1ST_LINE = new Color(255, 0, 0);
-	public static final Color COLOR_2ND_LINE = new Color(0, 255, 0);
-	public static final Color COLOR_3RD_LINE = new Color(0, 0, 255);
-	public static final Color COLOR_4TH_LINE = new Color(255, 255, 0);
+	public static final Color COLOR_2ND_LINE = new Color(225, 255, 0);
+	public static final Color COLOR_3RD_LINE = new Color(255, 0, 255);
+	public static final Color COLOR_4TH_LINE = new Color(0, 255, 0);
 	public static final Color COLOR_5TH_LINE = new Color(0, 255, 255);
-	public static final Color COLOR_6TH_LINE = new Color(255, 0, 255);
+	public static final Color COLOR_6TH_LINE = new Color(128, 128, 255);
+	public static final Color COLOR_7TH_LINE = new Color(128, 0, 0);
+	public static final Color COLOR_8TH_LINE = new Color(0, 128, 0);
 	
 	private List<TextPresentation> textPresentations = new ArrayList<>(4);
 	
@@ -68,54 +76,64 @@ public class DocumentLinkReconcilingTest extends AbstractTestWithProject {
 		MockLanguageServer.INSTANCE.setDocumentLinks(CONTENT_LINKS);
 
 		TextViewer viewer = (TextViewer) TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, CONTENT));
-		IDocument document = viewer.getDocument();
+		IDocument doc = viewer.getDocument();
+		var pos = 0;
+		var len = 0;
 		viewer.getTextWidget().setStyleRanges(new StyleRange[] {
-				textStyle(0, 25, COLOR_1ST_LINE), // whole 1st line
-				textStyle(25, 22, COLOR_2ND_LINE), // whole 2nd line
-				textStyle(47, 36, COLOR_3RD_LINE), // whole 3rd line
-				textStyle(83, 25, COLOR_4TH_LINE), // whole 4th line
-				textStyle(108, 33, COLOR_5TH_LINE), // whole 5th line
-				textStyle(141, 15, COLOR_6TH_LINE) // whole 6th line
+				textStyle(pos, len = doc.getLineLength(0), COLOR_1ST_LINE), // whole 1st line
+				textStyle(pos += len, len = doc.getLineLength(1), COLOR_2ND_LINE), // whole 2nd line
+				textStyle(pos += len, len = doc.getLineLength(2), COLOR_3RD_LINE), // whole 3rd line
+				textStyle(pos += len, len = doc.getLineLength(3), COLOR_4TH_LINE), // whole 4th line
+				textStyle(pos += len, len = doc.getLineLength(4), COLOR_5TH_LINE), // whole 5th line
+				textStyle(pos += len, len = doc.getLineLength(5), COLOR_6TH_LINE), // whole 6th line
+				textStyle(pos += len, len = doc.getLineLength(6), COLOR_7TH_LINE), // whole 7th line
+				textStyle(pos += len, doc.getLineLength(7), COLOR_8TH_LINE) // whole 8th line
 		});
 		viewer.addTextPresentationListener(this::textPresentationListener);
 		
-		TestUtils.waitForAndAssertCondition(1_000, () -> textPresentations.size() == 6);
+		TestUtils.waitForAndAssertCondition(1_000, () -> textPresentations.size() == 7);
 		
-		assertEquals(linkRegion(CONTENT_LINKS.get(0), document), textPresentations.get(0).getExtent());
-		assertEquals(linkRegion(CONTENT_LINKS.get(1), document), textPresentations.get(1).getExtent());
-		assertEquals(linkRegion(CONTENT_LINKS.get(2), document), textPresentations.get(2).getExtent());
-		assertEquals(linkRegion(CONTENT_LINKS.get(3), document), textPresentations.get(3).getExtent());
-		assertEquals(linkRegion(CONTENT_LINKS.get(4), document), textPresentations.get(4).getExtent());
-		assertEquals(linkRegion(CONTENT_LINKS.get(5), document), textPresentations.get(5).getExtent());
+		assertEquals(linkRegion(0, doc), textPresentations.get(0).getExtent());
+		assertEquals(linkRegion(1, doc), textPresentations.get(1).getExtent());
+		assertEquals(linkRegion(2, doc), textPresentations.get(2).getExtent());
+		assertEquals(linkRegion(3, doc), textPresentations.get(3).getExtent());
+		assertEquals(linkRegion(4, doc), textPresentations.get(4).getExtent());
+		assertEquals(linkRegion(5, doc), textPresentations.get(5).getExtent());
+		assertEquals(linkRegion(6, doc), textPresentations.get(6).getExtent());
 		
 		var styles = viewer.getTextWidget().getStyleRanges();
 		
-		assertEquals(17, styles.length);
+		assertEquals(20, styles.length);
 		
-		var pos = 0;
-		var length = 0;
-		assertEquals(textStyle(pos, length = 9, COLOR_1ST_LINE), styles[0]);
-		assertEquals(linkStyle(pos += length, length = 6, COLOR_1ST_LINE), styles[1]);
-		assertEquals(textStyle(pos += length, length = 9 + 1, COLOR_1ST_LINE), styles[2]); // also new line char
+		pos = 0;
+		len = 0;
+		assertEquals(textStyle(pos, len = 9, COLOR_1ST_LINE), styles[0]);
+		assertEquals(linkStyle(pos += len, len = 6, COLOR_1ST_LINE), styles[1]);
+		assertEquals(textStyle(pos += len, len = 9 + 1, COLOR_1ST_LINE), styles[2]); // also new line char
 		
-		assertEquals(textStyle(pos += length, length = 9, COLOR_2ND_LINE), styles[3]);
-		assertEquals(linkStyle(pos += length, length = 12 + 1, COLOR_2ND_LINE), styles[4]); // also new line char
+		assertEquals(textStyle(pos += len, len = 9, COLOR_2ND_LINE), styles[3]);
+		assertEquals(linkStyle(pos += len, len = 12 + 1, COLOR_2ND_LINE), styles[4]); // also new line char
 		
-		assertEquals(linkStyle(pos += length, length = 10, COLOR_3RD_LINE), styles[5]);
-		assertEquals(textStyle(pos += length, length = 10, COLOR_3RD_LINE), styles[6]);
-		assertEquals(linkStyle(pos += length, length = 6, COLOR_3RD_LINE), styles[7]);
-		assertEquals(textStyle(pos += length, length = 9 + 1, COLOR_3RD_LINE), styles[8]); // also new line char
+		assertEquals(linkStyle(pos += len, len = 10, COLOR_3RD_LINE), styles[5]);
+		assertEquals(textStyle(pos += len, len = 10, COLOR_3RD_LINE), styles[6]);
+		assertEquals(linkStyle(pos += len, len = 6, COLOR_3RD_LINE), styles[7]);
+		assertEquals(textStyle(pos += len, len = 9 + 1, COLOR_3RD_LINE), styles[8]); // also new line char
 		
-		assertEquals(textStyle(pos += length, length = 9, COLOR_4TH_LINE), styles[9]);
-		assertEquals(linkStyle(pos += length, length = 6, COLOR_4TH_LINE), styles[10]);
-		assertEquals(textStyle(pos += length, length = 9 + 1, COLOR_4TH_LINE), styles[11]); // also new line char
+		assertEquals(linkStyle(pos += len, len = 6, COLOR_4TH_LINE), styles[9]);
+		assertEquals(textStyle(pos += len, len = 1, COLOR_4TH_LINE), styles[10]); // new line char
 		
-		assertEquals(textStyle(pos += length, length = 9, COLOR_5TH_LINE), styles[12]);
-		assertEquals(linkStyle(pos += length, length = 23, COLOR_5TH_LINE), styles[13]);
-		assertEquals(textStyle(pos += length, length = 1, COLOR_5TH_LINE), styles[14]); // new line char
+		assertEquals(textStyle(pos += len, len = 9, COLOR_5TH_LINE), styles[11]);
+		assertEquals(linkStyle(pos += len, len = 23, COLOR_5TH_LINE), styles[12]);
+		assertEquals(textStyle(pos += len, len = 1, COLOR_5TH_LINE), styles[13]); // new line char
 
-		assertEquals(textStyle(pos += length, length = 9, COLOR_6TH_LINE), styles[15]);
-		assertEquals(linkStyle(pos += length, length = 6, COLOR_6TH_LINE), styles[16]);
+		assertEquals(linkStyle(pos += len, len = 12 + 1, COLOR_6TH_LINE), styles[14]); // also new line char
+		
+		assertEquals(linkStyle(pos += len, len = 10, COLOR_7TH_LINE), styles[15]);
+		assertEquals(textStyle(pos += len, len = 1, COLOR_7TH_LINE), styles[16]); // new line char
+		
+		assertEquals(textStyle(pos += len, len = 9, COLOR_8TH_LINE), styles[17]);
+		assertEquals(linkStyle(pos += len, len = 6, COLOR_8TH_LINE), styles[18]);
+		assertEquals(textStyle(pos += len, 9, COLOR_8TH_LINE), styles[19]);
 	}
 
 	@Test
@@ -123,47 +141,111 @@ public class DocumentLinkReconcilingTest extends AbstractTestWithProject {
 		MockLanguageServer.INSTANCE.setDocumentLinks(CONTENT_LINKS);
 		
 		TextViewer viewer = (TextViewer) TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, CONTENT));
-		IDocument document = viewer.getDocument();
-		int thirdLineStart = document.getLineOffset(2);
-		int untilMiddleOfLink5 = document.getLength() - thirdLineStart - document.getLineLength(5) - 1 - 11; 
-		// set visible region to 3rd + 4th + half of 5th line - link1 and link6 are out of visible region completely
-		// this triggers reconciliation by LSPDocumentLinkPresentationReconcilingStrategy
+		IDocument doc = viewer.getDocument();
+		int line5visibleLength = 21;
+		int line3Start = doc.getLineOffset(2);
+		int middleOfLink5 = doc.getLineOffset(4) + line5visibleLength;
+		// set visible region to 3rd + 4th + half of 5th line, link1 + link6 + link7 are completely outside
 		viewer.setVisibleRegion(
-				thirdLineStart, // TextViewer would align start of visible region to start of the line anyway
-				untilMiddleOfLink5);
+				line3Start, // TextViewer would align start of visible region to start of the line anyway
+				middleOfLink5 - line3Start);
+		var pos = 0;
+		var len = 0;
 		viewer.getTextWidget().setStyleRanges(new StyleRange[] {
-				textStyle(0, 36, COLOR_3RD_LINE), // whole 3rd line
-				textStyle(36, 25, COLOR_4TH_LINE), // whole 4th line
-				textStyle(61, 21, COLOR_5TH_LINE) // whole last displayed line - visible part of 5th line
+				textStyle(pos += len, len = doc.getLineLength(2), COLOR_3RD_LINE), // whole 3rd line
+				textStyle(pos += len, len = doc.getLineLength(3), COLOR_4TH_LINE), // whole 4th line
+				textStyle(pos += len, line5visibleLength, COLOR_5TH_LINE) // visible part of 5th line
 		});
 		viewer.addTextPresentationListener(this::textPresentationListener);
 		
-		TestUtils.waitForAndAssertCondition(1_000, () -> textPresentations.size() == 6);
+		TestUtils.waitForAndAssertCondition(1_000, () -> textPresentations.size() == 4);
 		
-		assertEquals(linkRegion(CONTENT_LINKS.get(0), document), textPresentations.get(0).getExtent());
-		assertEquals(linkRegion(CONTENT_LINKS.get(1), document), textPresentations.get(1).getExtent());
-		assertEquals(linkRegion(CONTENT_LINKS.get(2), document), textPresentations.get(2).getExtent());
-		assertEquals(linkRegion(CONTENT_LINKS.get(3), document), textPresentations.get(3).getExtent());
-		assertEquals(linkRegion(CONTENT_LINKS.get(4), document), textPresentations.get(4).getExtent());
-		assertEquals(linkRegion(CONTENT_LINKS.get(5), document), textPresentations.get(5).getExtent());
+		// no textPresentation for link1
+		assertEquals(tail(linkRegion(1, doc), 10), textPresentations.get(0).getExtent()); // visible 2nd part of link2
+		assertEquals(linkRegion(2, doc), textPresentations.get(1).getExtent()); // whole link3
+		assertEquals(linkRegion(3, doc), textPresentations.get(2).getExtent()); // whole link4
+		assertEquals(head(linkRegion(4, doc), 12), textPresentations.get(3).getExtent()); // visible 1st part of link5
+		// no textPresentation for link6
+		// no textPresentation for link7
 		
 		var styles = viewer.getTextWidget().getStyleRanges();
 		
-		assertEquals(9, styles.length);
+		assertEquals(8, styles.length);
+		
+		pos = 0;
+		len = 0;
+		assertEquals(linkStyle(pos, len = 10, COLOR_3RD_LINE), styles[0]);
+		assertEquals(textStyle(pos += len, len = 10, COLOR_3RD_LINE), styles[1]);
+		assertEquals(linkStyle(pos += len, len = 6, COLOR_3RD_LINE), styles[2]);
+		assertEquals(textStyle(pos += len, len = 9 + 1, COLOR_3RD_LINE), styles[3]); // also new line char
+		
+		assertEquals(linkStyle(pos += len, len = 6, COLOR_4TH_LINE), styles[4]);
+		assertEquals(textStyle(pos += len, len = 1, COLOR_4TH_LINE), styles[5]); // new line char
+		
+		assertEquals(textStyle(pos += len, len = 9, COLOR_5TH_LINE), styles[6]);
+		assertEquals(linkStyle(pos += len, 12, COLOR_5TH_LINE), styles[7]);
+	}
+	
+	@Test
+	public void testDocumentWithFoldingLinkReconciling() throws Exception {
+		MockLanguageServer.INSTANCE.setDocumentLinks(CONTENT_LINKS);
+		
+		ProjectionViewer viewer = (ProjectionViewer) TestUtils.openTextViewer(TestUtils.createUniqueTestFile(project, CONTENT));
+		IDocument doc = viewer.getDocument();
+		// line 1 visible
+		foldLines(0, 1, viewer); // fold line 2 into line 1
+		// line 3 visible
+		// line 4 visible
+		foldLines(3, 4, viewer); // fold line 5 into line 4
+		// line 6 visible
+		foldLines(5, 6, viewer); // fold line 7 into line 6
+		// line 8 visible
 		
 		var pos = 0;
-		var length = 0;
-		assertEquals(linkStyle(pos, length = 10, COLOR_3RD_LINE), styles[0]);
-		assertEquals(textStyle(pos += length, length = 10, COLOR_3RD_LINE), styles[1]);
-		assertEquals(linkStyle(pos += length, length = 6, COLOR_3RD_LINE), styles[2]);
-		assertEquals(textStyle(pos += length, length = 9 + 1, COLOR_3RD_LINE), styles[3]); // also new line char
+		var len = 0;
+		viewer.getTextWidget().setStyleRanges(new StyleRange[] {
+				textStyle(pos, len = doc.getLineLength(0), COLOR_1ST_LINE), // whole 1st line
+				textStyle(pos += len, len = doc.getLineLength(2), COLOR_3RD_LINE), // whole 3rd line
+				textStyle(pos += len, len = doc.getLineLength(3), COLOR_4TH_LINE), // whole 4th line
+				textStyle(pos += len, len = doc.getLineLength(5), COLOR_6TH_LINE), // whole 6th line
+				textStyle(pos += len, doc.getLineLength(7), COLOR_8TH_LINE) // whole 8th line
+		});
+		viewer.addTextPresentationListener(this::textPresentationListener);
 		
-		assertEquals(textStyle(pos += length, length = 9, COLOR_4TH_LINE), styles[4]);
-		assertEquals(linkStyle(pos += length, length = 6, COLOR_4TH_LINE), styles[5]);
-		assertEquals(textStyle(pos += length, length = 9 + 1, COLOR_4TH_LINE), styles[6]); // also new line char
+		TestUtils.waitForAndAssertCondition(10_000, () -> textPresentations.size() == 6);
 		
-		assertEquals(textStyle(pos += length, length = 9, COLOR_5TH_LINE), styles[7]);
-		assertEquals(linkStyle(pos += length, length = 12, COLOR_5TH_LINE), styles[8]);
+		assertEquals(linkRegion(0, doc), textPresentations.get(0).getExtent()); // whole link1
+		assertEquals(tail(linkRegion(1, doc), 10), textPresentations.get(1).getExtent()); // visible 2nd part of link2
+		assertEquals(linkRegion(2, doc), textPresentations.get(2).getExtent()); // whole link3
+		assertEquals(linkRegion(3, doc), textPresentations.get(3).getExtent()); // whole link4
+		// no textPresentation for link5
+		assertEquals(head(linkRegion(5, doc), 12), textPresentations.get(4).getExtent()); // visible 1st part of link6
+		// no textPresentation for link7
+		assertEquals(linkRegion(6, doc), textPresentations.get(5).getExtent()); // whole link7
+		
+		var styles = viewer.getTextWidget().getStyleRanges();
+		
+		assertEquals(13, styles.length);
+		
+		pos = 0;
+		len = 0;
+		assertEquals(textStyle(pos, len = 9, COLOR_1ST_LINE), styles[0]);
+		assertEquals(linkStyle(pos += len, len = 6, COLOR_1ST_LINE), styles[1]);
+		assertEquals(textStyle(pos += len, len = 9 + 1, COLOR_1ST_LINE), styles[2]); // also new line char
+		
+		assertEquals(linkStyle(pos += len, len = 10, COLOR_3RD_LINE), styles[3]);
+		assertEquals(textStyle(pos += len, len = 10, COLOR_3RD_LINE), styles[4]);
+		assertEquals(linkStyle(pos += len, len = 6, COLOR_3RD_LINE), styles[5]);
+		assertEquals(textStyle(pos += len, len = 9 + 1, COLOR_3RD_LINE), styles[6]); // also new line char
+		
+		assertEquals(linkStyle(pos += len, len = 6, COLOR_4TH_LINE), styles[7]);
+		assertEquals(textStyle(pos += len, len = 1, COLOR_4TH_LINE), styles[8]); // new line char
+		
+		assertEquals(linkStyle(pos += len, len = 12 + 1, COLOR_6TH_LINE), styles[9]); // also new line char
+		
+		assertEquals(textStyle(pos += len, len = 9, COLOR_8TH_LINE), styles[10]);
+		assertEquals(linkStyle(pos += len, len = 6, COLOR_8TH_LINE), styles[11]);
+		assertEquals(textStyle(pos += len, 9, COLOR_8TH_LINE), styles[12]);
 	}
 	
 	private StyleRange textStyle(int start, int length, Color backgroundColor ) {
@@ -176,11 +258,29 @@ public class DocumentLinkReconcilingTest extends AbstractTestWithProject {
 		return retVal;
 	}
 
-	private Region linkRegion(DocumentLink link, IDocument document) throws BadLocationException {
+	private Region linkRegion(int contentlinkPos, IDocument document) throws BadLocationException {
+		DocumentLink link = CONTENT_LINKS.get(contentlinkPos);
 		var start = link.getRange().getStart();
 		var end = link.getRange().getEnd();
 		int startOffset = document.getLineOffset(start.getLine()) + start.getCharacter();
 		return new Region(startOffset, (document.getLineOffset(end.getLine()) + end.getCharacter()) - startOffset);
+	}
+	
+	private Region head(Region region, int length) {
+		return new Region(region.getOffset(), length);
+	}
+	
+	private Region tail(Region region, int length) {
+		return new Region(region.getOffset() + region.getLength() - length, length);
+	}
+	
+	private void foldLines(int startLine, int endLine, ProjectionViewer viewer) throws BadLocationException {
+		var doc = viewer.getDocument();
+		int firstLineOffset = doc.getLineOffset(startLine);
+		int lastLineEndOffset = doc.getLineOffset(endLine) + doc.getLineLength(endLine);
+		viewer.getProjectionAnnotationModel().addAnnotation(
+				new ProjectionAnnotation(true),
+				new org.eclipse.jface.text.Position(firstLineOffset, lastLineEndOffset - firstLineOffset));
 	}
 
 	private void textPresentationListener(TextPresentation textPresentation) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/LSPDocumentLinkPresentationReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/LSPDocumentLinkPresentationReconcilingStrategy.java
@@ -5,6 +5,9 @@
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Jozef Tomek - fix getting misaligned style ranges (#1220)
  *******************************************************************************/
 package org.eclipse.lsp4e.operations.documentLink;
 
@@ -101,64 +104,42 @@ public class LSPDocumentLinkPresentationReconcilingStrategy
 				int start = LSPEclipseUtils.toOffset(link.getRange().getStart(), document);
 				int end = LSPEclipseUtils.toOffset(link.getRange().getEnd(), document);
 				int length = end - start;
-				var linkRegion = new Region(start, length);
-				// Update existing style range with underline or create a new style range with underline
+				final var linkRegion = new Region(start, length);
+
+				// Update existing style range with underline or create a new style range with
+				// underline
 				StyleRange styleRange = null;
 				StyleRange[] styleRanges = null;
-				int startOffset = 0;
 				if (textViewer != null) {
 					// returns widget region just for visible part of link region
 					var widgetRange = textViewer.modelRange2WidgetRange(linkRegion);
 					if (widgetRange != null) {
 						int widgetOffset = widgetRange.getOffset();
 						styleRanges = textViewer.getTextWidget().getStyleRanges(widgetOffset, widgetRange.getLength());
+						if (styleRanges != null && styleRanges.length > 0) {
+							// There are some styles for the range of document link, update just the underline style.
 
-						// only part of the link area may be visible, so we need to adjust our document coordinates
-						int visibleStart = textViewer.widgetOffset2ModelOffset(widgetOffset);
-						int visibleLength =
-								textViewer.widgetOffset2ModelOffset(widgetOffset + widgetRange.getLength())
-								- visibleStart;
-						startOffset = visibleStart - widgetOffset;
-						if (visibleLength > linkRegion.getLength()) {
-							/*
-							 * It's possible that link falls into a folded area in a such way that
-							 * translating widget range back to document range results in larger range, in
-							 * which case we must back-off by 1 from widget range.
-							 *
-							 * Example:
-							 * 1     text of visible line
-							 * 2*    start-of-the-link
-							 * 3*    end-of-the-link
-							 * 4     text of visible line
-							 *
-							 * Line 3 is folded into line 2, therefore not visible.
-							 * Link range spanning region until end of line 3 (includes line 2 terminator but not
-							 * line 3 terminator) is translated to widget range spanning whole line 2 including it's
-							 * line terminator. Since visually 4th line starts right after line terminator at the end
-							 * of line 2, when translated back to document range it becomes region spanning line 2 and 3
-							 * until start of line 4, therefore line 3 terminator as well - region larger than link.
-							 */
-							visibleLength =
-								textViewer.widgetOffset2ModelOffset(widgetOffset + widgetRange.getLength() - 1)
-								- visibleStart;
+							// only part of the link area may be visible, so we need to adjust our document coordinates
+							int visibleStart = textViewer.widgetOffset2ModelOffset(widgetOffset);
+							int startOffset = visibleStart - widgetOffset;
+							for (StyleRange s : styleRanges) {
+								s.underline = true;
+								s.start += startOffset; // shift to align with start of link in document coordinates
+							}
+							// fill the gaps at the start/end of the link region if not fully covered by existing styles
+							styleRanges = fillStartEndGaps(styleRanges, start, end);
 						}
-						if (visibleStart > linkRegion.getOffset() || visibleLength < linkRegion.getLength()) {
-							linkRegion = new Region(visibleStart, visibleLength);
-						}
-					} else {
-						// whole link is not visible - outside model coverage (visible region) or inside folded areas
-						continue;
 					}
 				} else {
 					styleRanges = viewer.getTextWidget().getStyleRanges(start, length);
+					if (styleRanges != null && styleRanges.length > 0) {
+						// There are some styles for the range of document link, update just the underline style.
+						for (StyleRange s : styleRanges) {
+							s.underline = true;
+						}
+					}
 				}
 				if (styleRanges != null && styleRanges.length > 0) {
-					// It exists some styles for the range of document link, update just the
-					// underline style.
-					for (StyleRange s : styleRanges) {
-						s.underline = true;
-						s.start += startOffset; // shift to align with start of link (in document coordinates)
-					}
 					final var presentation = new TextPresentation(linkRegion, 100);
 					presentation.replaceStyleRanges(styleRanges);
 					viewer.changeTextPresentation(presentation, false);
@@ -179,6 +160,34 @@ public class LSPDocumentLinkPresentationReconcilingStrategy
 				LanguageServerPlugin.logError(e);
 			}
 		}
+	}
+
+	private StyleRange[] fillStartEndGaps(StyleRange[] styleRanges, int linkStart, int linkEnd) {
+		var lastStyle = styleRanges[styleRanges.length - 1];
+		int startGap = styleRanges[0].start - linkStart;
+		int endGap = linkEnd - (lastStyle.start + lastStyle.length);
+		int stylesToAdd = startGap > 0 ? 1 : 0 + endGap > 0 ? 1 : 0;
+		if (stylesToAdd > 0) {
+			StyleRange[] modifiedRanges = new StyleRange[styleRanges.length + stylesToAdd];
+			StyleRange styleRange;
+			if (startGap > 0) {
+				System.arraycopy(styleRanges, 0, modifiedRanges, 1, styleRanges.length);
+				modifiedRanges[0] = styleRange = new StyleRange();
+				styleRange.underline = true;
+				styleRange.start = linkStart;
+				styleRange.length = startGap;
+			} else {
+				System.arraycopy(styleRanges, 0, modifiedRanges, 0, styleRanges.length);
+			}
+			if (endGap > 0) {
+				modifiedRanges[modifiedRanges.length - 1] = styleRange = new StyleRange();
+				styleRange.underline = true;
+				styleRange.start = linkEnd - endGap;
+				styleRange.length = endGap;
+			}
+			return modifiedRanges;
+		}
+		return styleRanges;
 	}
 
 	@Override


### PR DESCRIPTION
Before
![Image](https://github.com/user-attachments/assets/3b539dea-b582-491b-a475-e58ed6a221fb)
After
![image](https://github.com/user-attachments/assets/e18144f7-0f83-413c-a355-49b0f6dbd0a2)
(with quick-reproducer-code mentioned in #1220 )

(I haven't checked LSP4E repository for other possible places where widget's style ranges may be considered to have viewer's document (model) coordinates)
