### PR TITLE
LS completions relevance in Java editor

### DIFF
--- a/org.eclipse.lsp4e.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JDT Integration for LSP4E
 Bundle-SymbolicName: org.eclipse.lsp4e.jdt;singleton:=true
-Bundle-Version: 0.13.4.qualifier
+Bundle-Version: 0.13.5.qualifier
 Automatic-Module-Name: org.eclipse.lsp4e.jdt
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ClassPath: .
@@ -14,4 +14,5 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.lsp4e;bundle-version="0.18.13",
  org.eclipse.jdt.core;bundle-version="3.20.0",
  org.eclipse.jdt.ui;bundle-version="3.20.0",
- org.eclipse.swt
+ org.eclipse.swt,
+ org.eclipse.lsp4j


### PR DESCRIPTION
Rather than just push LS proposals at the top of the proposals list attempt to compute relevance in java editor completion terms. Compute base relevance based on LSP4E proposal category and rank.