### PR TITLE
fix: automatically invalidate moved/deleted entries from the ResourceForUriCache

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/ResourceForUriCache.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/ResourceForUriCache.java
@@ -46,8 +46,8 @@ public final class ResourceForUriCache {
 	 * if it's not already in the cache. Returns NULL if the IResource could not be determined,
 	 * e.g. the URI points to a file outside the workspace.
 	 *
-	 * <p>NOTE: In case a resource has been moved or deleted the entry will not be removed automatically.
-	 * It's up to the caller to check if the resource is accessible.
+	 * <p>In case a resource has been moved or deleted, the cache entry will be invalidated,
+	 * and this method will re-attempt to find the IResource.
 	 * @param uri
 	 * @return IResource or NULL
 	 */
@@ -61,7 +61,10 @@ public final class ResourceForUriCache {
 		if (localURI != null) {
 			resource = cache.getIfPresent(localURI);
 			if (resource != null) {
-				return resource;
+				if (resource.isAccessible()) {
+					return resource;
+				}
+				cache.invalidate(localURI);
 			}
 			resource = findResourceFor(localURI);
 			if (resource != null) {


### PR DESCRIPTION
If a resource is moved or deleted, it's possible that the resource stored for its URI in the ResourceForUriCache stops being `accessible`.

This commit changes `ResourceForUriCache.get(URI)` so that, if a resource is present in the cache but is no longer accessible, the corresponding cache entry is invalidated. In this case, `.get(URI)` then tries to determine the up-to-date IResource again.

Fixes a regression introduced in https://github.com/eclipse-lsp4e/lsp4e/pull/1208. Specifically, this commit
addresses the concern raised in https://github.com/eclipse-lsp4e/lsp4e/pull/1208#discussion_r1942357586