### PR TITLE
fix: "SWTException: Widget is disposed" in CNFOutlinePage#refreshTreeSelection

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/CNFOutlinePage.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/CNFOutlinePage.java
@@ -44,12 +44,12 @@ import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4e.LanguageServerWrapper;
 import org.eclipse.lsp4e.outline.LSSymbolsContentProvider.OutlineViewerInput;
 import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithURI;
+import org.eclipse.lsp4e.ui.UI;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.navigator.CommonViewer;
 import org.eclipse.ui.navigator.CommonViewerSorter;
@@ -211,10 +211,12 @@ public class CNFOutlinePage implements IContentOutlinePage, ILabelProviderListen
 				// the symbol to select is the same than current selected symbol, don't select it.
 				return;
 			}
-			Display.getDefault().asyncExec(() -> {
-				final var treePath = new TreePath(path.toArray());
-				viewer.reveal(treePath);
-				viewer.setSelection(new TreeSelection(treePath), true);
+			UI.runOnUIThread(() -> {
+				if(!viewer.getControl().isDisposed()) {
+					final var treePath = new TreePath(path.toArray());
+					viewer.reveal(treePath);
+					viewer.setSelection(new TreeSelection(treePath), true);
+				}
 			});
 		}
 	}


### PR DESCRIPTION
Addresses the following sporadic exception seen in the log.

```py
org.eclipse.swt.SWTException: Widget is disposed
	at org.eclipse.swt.SWT.error(SWT.java:4932)
	at org.eclipse.swt.SWT.error(SWT.java:4847)
	at org.eclipse.swt.SWT.error(SWT.java:4818)
	at org.eclipse.swt.widgets.Widget.error(Widget.java:501)
	at org.eclipse.swt.widgets.Widget.checkWidget(Widget.java:420)
	at org.eclipse.swt.widgets.Tree.getItems(Tree.java:3389)
	at org.eclipse.jface.viewers.TreeViewer.getChildren(TreeViewer.java:165)
	at org.eclipse.jface.viewers.AbstractTreeViewer.createChildren(AbstractTreeViewer.java:839)
	at org.eclipse.jface.viewers.TreeViewer.createChildren(TreeViewer.java:611)
	at org.eclipse.jface.viewers.AbstractTreeViewer.createChildren(AbstractTreeViewer.java:818)
	at org.eclipse.jface.viewers.AbstractTreeViewer.internalExpand(AbstractTreeViewer.java:1737)
	at org.eclipse.jface.viewers.AbstractTreeViewer.reveal(AbstractTreeViewer.java:2420)
	at org.eclipse.lsp4e.outline.CNFOutlinePage.lambda$2(CNFOutlinePage.java:216)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:40)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:132)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4094)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3710)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1151)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1042)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:668)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:576)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:173)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:178)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:208)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:149)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:115)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:467)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:298)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:670)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:607)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1492)
```