### PR TITLE
fix: defer browser evaluations until DOM is ready in hover control

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/FocusableBrowserInformationControl.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/FocusableBrowserInformationControl.java
@@ -34,6 +34,7 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.tm4e.ui.internal.utils.UI;
 import org.eclipse.ui.editors.text.EditorsUI;
 import org.eclipse.ui.texteditor.AbstractDecoratedTextEditorPreferenceConstants;
 
@@ -92,10 +93,18 @@ public class FocusableBrowserInformationControl extends BrowserInformationContro
 	}
 
 	private void updateBrowserSize(final Browser browser) {
+		if (browser.isDisposed())
+			return;
+
 		@Nullable
 		Point constraints = getSizeConstraints();
 		Point hint = computeSizeHint();
 		setSize(hint.x, hint.y);
+
+		if (!"complete".equals(safeEvaluate(browser, "return document.readyState"))) { //$NON-NLS-1$ //$NON-NLS-2$
+			UI.getDisplay().timerExec(200, () -> updateBrowserSize(browser));
+			return;
+		}
 
 		safeExecute(browser, "document.getElementsByTagName(\"html\")[0].style.whiteSpace = \"nowrap\""); //$NON-NLS-1$
 		Double width = 20 + (safeEvaluate(browser, "return document.body.scrollWidth;") instanceof Double evaluated ? evaluated : 0); //$NON-NLS-1$

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/FocusableBrowserInformationControl.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/hover/FocusableBrowserInformationControl.java
@@ -86,41 +86,45 @@ public class FocusableBrowserInformationControl extends BrowserInformationContro
 			if (getInput() == null)
 				return;
 			final var browser = (Browser) event.getSource();
-			@Nullable
-			Point constraints = getSizeConstraints();
-			Point hint = computeSizeHint();
-			setSize(hint.x, hint.y);
-
-			safeExecute(browser, "document.getElementsByTagName(\"html\")[0].style.whiteSpace = \"nowrap\""); //$NON-NLS-1$
-			Double width = 20 + (safeEvaluate(browser, "return document.body.scrollWidth;") instanceof Double evaluated ? evaluated : 0); //$NON-NLS-1$
-			setSize(width.intValue(), hint.y);
-
-			safeExecute(browser, "document.getElementsByTagName(\"html\")[0].style.whiteSpace = \"normal\""); //$NON-NLS-1$
-			Double height = safeEvaluate(browser, "return document.body.scrollHeight;") instanceof Double evaluated ? evaluated : 0; //$NON-NLS-1$
-			Object marginTop = safeEvaluate(browser, "return window.getComputedStyle(document.body).marginTop;"); //$NON-NLS-1$
-			Object marginBottom = safeEvaluate(browser, "return window.getComputedStyle(document.body).marginBottom;"); //$NON-NLS-1$
-			if (Platform.getPreferencesService().getBoolean(EditorsUI.PLUGIN_ID,
-					AbstractDecoratedTextEditorPreferenceConstants.EDITOR_SHOW_TEXT_HOVER_AFFORDANCE, true,
-					null)) {
-				FontData[] fontDatas = JFaceResources.getDialogFont().getFontData();
-				height += fontDatas[0].getHeight();
-			}
-
-			width = width * 1.5;
-			if (Util.isWin32()) {
-				height = adjust(height, marginTop);
-				height = adjust(height, marginBottom);
-			}
-			if (constraints != null && constraints.x < width) {
-				width = (double) constraints.x;
-			}
-			if (constraints != null && constraints.y < height) {
-				height = (double) constraints.y;
-			}
-
-			setSize(width.intValue(), height.intValue());
+			updateBrowserSize(browser);
 		}));
 		b.setJavascriptEnabled(true);
+	}
+
+	private void updateBrowserSize(final Browser browser) {
+		@Nullable
+		Point constraints = getSizeConstraints();
+		Point hint = computeSizeHint();
+		setSize(hint.x, hint.y);
+
+		safeExecute(browser, "document.getElementsByTagName(\"html\")[0].style.whiteSpace = \"nowrap\""); //$NON-NLS-1$
+		Double width = 20 + (safeEvaluate(browser, "return document.body.scrollWidth;") instanceof Double evaluated ? evaluated : 0); //$NON-NLS-1$
+		setSize(width.intValue(), hint.y);
+
+		safeExecute(browser, "document.getElementsByTagName(\"html\")[0].style.whiteSpace = \"normal\""); //$NON-NLS-1$
+		Double height = safeEvaluate(browser, "return document.body.scrollHeight;") instanceof Double evaluated ? evaluated : 0; //$NON-NLS-1$
+		Object marginTop = safeEvaluate(browser, "return window.getComputedStyle(document.body).marginTop;"); //$NON-NLS-1$
+		Object marginBottom = safeEvaluate(browser, "return window.getComputedStyle(document.body).marginBottom;"); //$NON-NLS-1$
+		if (Platform.getPreferencesService().getBoolean(EditorsUI.PLUGIN_ID,
+				AbstractDecoratedTextEditorPreferenceConstants.EDITOR_SHOW_TEXT_HOVER_AFFORDANCE, true,
+				null)) {
+			FontData[] fontDatas = JFaceResources.getDialogFont().getFontData();
+			height += fontDatas[0].getHeight();
+		}
+
+		width = width * 1.5;
+		if (Util.isWin32()) {
+			height = adjust(height, marginTop);
+			height = adjust(height, marginBottom);
+		}
+		if (constraints != null && constraints.x < width) {
+			width = (double) constraints.x;
+		}
+		if (constraints != null && constraints.y < height) {
+			height = (double) constraints.y;
+		}
+
+		setSize(width.intValue(), height.intValue());
 	}
 
 	private static @Nullable Object safeEvaluate(Browser browser, String expression) {


### PR DESCRIPTION
Ensure all JavaScript evaluations in `FocusableBrowserInformationControl` only occur after `document.readyState === 'complete'` to prevent runtime errors when accessing incomplete DOM elements, such as:
```py
org.eclipse.swt.SWTException: Cannot read properties of null (reading 'scrollWidth')
	at org.eclipse.swt.browser.Edge.evaluate(Edge.java:908)
	at org.eclipse.swt.browser.WebBrowser.evaluate(WebBrowser.java:405)
	at org.eclipse.swt.browser.Browser.evaluate(Browser.java:665)
	at org.eclipse.swt.browser.Browser.evaluate(Browser.java:614)
	at org.eclipse.lsp4e.operations.hover.FocusableBrowserInformationControl.safeEvaluate(FocusableBrowserInformationControl.java:128)
	at org.eclipse.lsp4e.operations.hover.FocusableBrowserInformationControl.lambda$0(FocusableBrowserInformationControl.java:95)
	at org.eclipse.swt.browser.ProgressListener$2.completed(ProgressListener.java:97)
	at org.eclipse.swt.browser.Edge.lambda$45(Edge.java:1109)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:40)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:132)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4094)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3710)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$5.run(PartRenderingEngine.java:1151)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1042)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:153)
	at org.eclipse.ui.internal.Workbench.lambda$3(Workbench.java:668)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:339)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:576)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:173)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:178)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:208)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:149)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:115)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:467)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:298)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:670)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:607)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1492)
```