### PR TITLE
Fix format without selected range when documentFormattingProvider=false

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
@@ -56,7 +56,7 @@ public class LSPFormatter {
 		// range formatting, falling back to a full format if unavailable
 		long modificationStamp = DocumentUtil.getDocumentModificationStamp(document);
 		return executor.computeFirst((w, ls) -> w.getServerCapabilitiesAsync().thenCompose(capabilities -> {
-			if (textSelection.getLength() != 0 && isDocumentRangeFormattingSupported(capabilities)) {
+			if (isDocumentRangeFormattingSupported(capabilities) && (textSelection.getLength() > 0 || !isDocumentFormattingSupported(capabilities))) {
 				return ls.getTextDocumentService().rangeFormatting(rangeParams)
 						.thenApply(edits -> new VersionedEdits(modificationStamp, edits, document));
 			} else if (isDocumentFormattingSupported(capabilities)) {


### PR DESCRIPTION
In case documentRangeFormattingProvider=true &&
documentFormattingProvider==false, the conditions were leading to no request being sent.
This commit reworks condition so that one may be used as a failback for the other when only one capability is set.

Fixes https://github.com/eclipse-wildwebdeveloper/wildwebdeveloper/issues/1835