### PR TITLE
JDT completions compatible with any `ICompletionProposal`

### DIFF
--- a/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LSJavaCompletionWrappingCompletionProposal.java
+++ b/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LSJavaCompletionWrappingCompletionProposal.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.jdt;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
@@ -32,12 +33,12 @@ class LSJavaCompletionWrappingCompletionProposal implements IJavaCompletionPropo
 	}
 
 	@Override
-	public Point getSelection(IDocument document) {
+	public @Nullable Point getSelection(IDocument document) {
 		return delegate.getSelection(document);
 	}
 
 	@Override
-	public String getAdditionalProposalInfo() {
+	public @Nullable String getAdditionalProposalInfo() {
 		return delegate.getAdditionalProposalInfo();
 	}
 
@@ -47,12 +48,12 @@ class LSJavaCompletionWrappingCompletionProposal implements IJavaCompletionPropo
 	}
 
 	@Override
-	public Image getImage() {
+	public @Nullable Image getImage() {
 		return delegate.getImage();
 	}
 
 	@Override
-	public IContextInformation getContextInformation() {
+	public @Nullable IContextInformation getContextInformation() {
 		return delegate.getContextInformation();
 	}
 

--- a/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LSJavaCompletionWrappingCompletionProposal.java
+++ b/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LSJavaCompletionWrappingCompletionProposal.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Broadcom Inc. and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  - Alex Boyko (Broadcom Inc.) - Initial implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.jdt;
+
+import org.eclipse.jdt.ui.text.java.IJavaCompletionProposal;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.contentassist.ICompletionProposal;
+import org.eclipse.jface.text.contentassist.IContextInformation;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Point;
+
+class LSJavaCompletionWrappingCompletionProposal implements IJavaCompletionProposal {
+	
+	private final ICompletionProposal delegate;
+	
+	public LSJavaCompletionWrappingCompletionProposal(ICompletionProposal delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public void apply(IDocument document) {
+		delegate.apply(document);
+	}
+
+	@Override
+	public Point getSelection(IDocument document) {
+		return delegate.getSelection(document);
+	}
+
+	@Override
+	public String getAdditionalProposalInfo() {
+		return delegate.getAdditionalProposalInfo();
+	}
+
+	@Override
+	public String getDisplayString() {
+		return delegate.getDisplayString();
+	}
+
+	@Override
+	public Image getImage() {
+		return delegate.getImage();
+	}
+
+	@Override
+	public IContextInformation getContextInformation() {
+		return delegate.getContextInformation();
+	}
+
+	@Override
+	public int getRelevance() {
+		return -1;
+	}
+
+}

--- a/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LspJavaQuickAssistProcessor.java
+++ b/org.eclipse.lsp4e.jdt/src/org/eclipse/lsp4e/jdt/LspJavaQuickAssistProcessor.java
@@ -64,10 +64,13 @@ public class LspJavaQuickAssistProcessor extends LSPCodeActionQuickAssistProcess
 		ICompletionProposal[] proposals = computeQuickAssistProposals(getContext(context));
 		if (proposals == null)
 			return NO_JAVA_COMPLETION_PROPOSALS;
-
-		return Arrays.stream(proposals).filter(LSCompletionProposal.class::isInstance)
-				.map(LSCompletionProposal.class::cast).map(LSJavaProposal::new).toArray(LSJavaProposal[]::new);
-
+		
+		return Arrays.stream(proposals).map(p -> {
+			if (p instanceof LSCompletionProposal lscp) {
+				return new LSJavaProposal(lscp);
+			}
+			return new LSJavaCompletionWrappingCompletionProposal(p);
+		}).toArray(IJavaCompletionProposal[]::new);
 	}
 
 }


### PR DESCRIPTION
JDT completions changes 1443a66b9c53cb6f91e5fc0f7805ec5e73f070ea broke CodeAction for JDT coming from LS. This change should restore the behaviour for CodeActions.