### PR TITLE
skip linked editing update on selection (size) changes

### DIFF
--- a/org.eclipse.lsp4e.jdt/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.jdt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: JDT Integration for LSP4E
 Bundle-SymbolicName: org.eclipse.lsp4e.jdt;singleton:=true
-Bundle-Version: 0.13.6.qualifier
+Bundle-Version: 0.13.7.qualifier
 Export-Package: org.eclipse.lsp4e.jdt
 Automatic-Module-Name: org.eclipse.lsp4e.jdt
 Bundle-Activator: org.eclipse.lsp4e.jdt.LanguageServerJdtPlugin

--- a/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for language server bundle (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.test;singleton:=true
-Bundle-Version: 0.15.25.qualifier
+Bundle-Version: 0.15.26.qualifier
 Fragment-Host: org.eclipse.lsp4e
 Bundle-Vendor: Eclipse LSP4E
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.lsp4e.test/pom.xml
+++ b/org.eclipse.lsp4e.test/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.15.25-SNAPSHOT</version>
+	<version>0.15.26-SNAPSHOT</version>
 
 	<properties>
 		<os-jvm-flags /> <!-- for the default case -->

--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.18.20.qualifier
+Bundle-Version: 0.18.21.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.18.20-SNAPSHOT</version>
+	<version>0.18.21-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/linkedediting/LSPLinkedEditingReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/linkedediting/LSPLinkedEditingReconcilingStrategy.java
@@ -152,7 +152,7 @@ public class LSPLinkedEditingReconcilingStrategy extends LSPLinkedEditingBase
 	}
 
 	private void updateLinkedEditing(ISelection selection) {
-		if (selection instanceof ITextSelection textSelection) {
+		if (selection instanceof ITextSelection textSelection && textSelection.getLength() == 0) {
 			updateLinkedEditing(textSelection.getOffset());
 		}
 	}


### PR DESCRIPTION
Fixes eclipse-wildwebdeveloper/wildwebdeveloper#1844

When selecting a range of characters spanning different linked editing ranges with the keyboard, it resets the selection moving the cursor to the end of the selection.

This PR fixes that issue by skipping that processing of linked editing ranges when the size of the selection changes as these don't seem to be necessary for the linked editing feature.

I don't know whether this is the best way of solving this issue (for example, it might be possible to somehow change the linked editing logic to not modify the selection and then reset it or to explicitly restore the cursor/caret position) but I wanted to at least show one way of doing it.

Alternatively, [applyLinkedEditing](https://github.com/eclipse-lsp4e/lsp4e/blob/0480a5b13ba86af99477812c1cbe9f316758154f/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/linkedediting/LSPLinkedEditingReconcilingStrategy.java#L216) could be changed to restore both the selection and the caret by [creating a selection with the end before the start](https://github.com/eclipse-platform/eclipse.platform.ui/discussions/2958#discussioncomment-13047053) similar to the one used in the test I added.



### How to test

- Run Eclipse with wildwebdeveloper.xml and the modified version of lsp4e (that's easiest to reproduce it with)
- Make a selection on the editor across multiple XML tags but start at the end of the selection (i.e. selecting backwards such that the caret should be at the beginning after the selection)
- Notice that the caret moves to the end of the selection.

If automated tests are necessary for fixes like that, I'd still have to figure out how to access the data there (`LinkedEditingTest` didn't seem to be that useful there until now).