### PR TITLE
fix: do not log timeouts as errors

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -167,6 +167,8 @@ public class LanguageServerWrapper {
 					shutdown.get(5, TimeUnit.SECONDS);
 				} catch (InterruptedException ex) {
 					Thread.currentThread().interrupt();
+				} catch (TimeoutException ex) {
+					LanguageServerPlugin.logWarning("The server did not stop after 5 seconds",ex); //$NON-NLS-1$
 				} catch (Exception ex) {
 					LanguageServerPlugin.logError(ex.getClass().getSimpleName() + " occurred during shutdown of " //$NON-NLS-1$
 							+ languageServer, ex);


### PR DESCRIPTION
instead, follow the overall pattern and log them as a warning.