### PR TITLE
fix: catch expected BadLocationException in LSPFoldingReconcilingStrategy

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerPlugin.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerPlugin.java
@@ -45,6 +45,7 @@ public class LanguageServerPlugin extends AbstractUIPlugin {
 	public static final Object FAMILY_INITIALIZE_LANGUAGE_SERVER = new Object();
 
 	public static final String PLUGIN_ID = "org.eclipse.lsp4e"; //$NON-NLS-1$
+	private static final String TRACE_ID = PLUGIN_ID + "/trace"; //$NON-NLS-1$
 
 	public static final boolean DEBUG = Boolean.parseBoolean(Platform.getDebugOption("org.eclipse.lsp4e/debug")); //$NON-NLS-1$
 
@@ -136,6 +137,15 @@ public class LanguageServerPlugin extends AbstractUIPlugin {
 		if (plugin != null) {
 			plugin.getLog().log(new Status(IStatus.WARNING, PLUGIN_ID, 0, message, thr));
 		}
+	}
+
+	/**
+	 * Returns whether log trace is enabled for this plugin.
+	 * 
+	 * @return true if the trace debug option is enabled, false otherwise
+	 */
+	public static boolean isLogTraceEnabled() {
+		return Boolean.parseBoolean(Platform.getDebugOption(TRACE_ID));
 	}
 
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/folding/LSPFoldingReconcilingStrategy.java
@@ -215,7 +215,10 @@ public class LSPFoldingReconcilingStrategy
 							updateAnnotation(deletions, existing, additions, foldingRange.getStartLine(),
 									foldingRange.getEndLine(), collapsByDefault);
 						} catch (BadLocationException ex) {
-							LanguageServerPlugin.logError(ex);
+							// This is an expected state, only log when tracing is enabled.
+							if (LanguageServerPlugin.isLogTraceEnabled()) {
+								LanguageServerPlugin.logError(ex);
+							}
 						}
 						isFirstFoldingRange[0] = false;
 					});


### PR DESCRIPTION
A document may be modified concurrently by multiple threads. This can cause `BadLocationException`s, which should not be logged unless the log trace is enabled for the LanguageServerPlugin.

Follows a similar pattern to:
https://github.com/eclipse-tm4e/tm4e/pull/888