### PR TITLE
Call underline() for region-based reconcile also

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.18.25.qualifier
+Bundle-Version: 0.18.26.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.18.25-SNAPSHOT</version>
+	<version>0.18.26-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/LSPDocumentLinkPresentationReconcilingStrategy.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/LSPDocumentLinkPresentationReconcilingStrategy.java
@@ -180,7 +180,9 @@ public class LSPDocumentLinkPresentationReconcilingStrategy
 
 	@Override
 	public void reconcile(DirtyRegion dirtyRegion, @Nullable IRegion subRegion) {
-		// Do nothing
+		// Underline document by using textDocument/documentLink with some delay as
+		// reconcile method is called in a Thread background.
+		underline();
 	}
 
 	@Override


### PR DESCRIPTION
Currently when a change is made in an `ExtensionBasedTextEditor` that uses document links, the links disappear. This is caused by the region-based `reconcile` method here intentionally doing nothing:

https://github.com/eclipse-lsp4e/lsp4e/blob/cc3fb63d9925b9acb57f299dd9511640d6482b8d/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/documentLink/LSPDocumentLinkPresentationReconcilingStrategy.java#L181-L184

This change adds support for editors that call this `reconcile` method on change.

See Issue #1305 for more details and example gifs showing the problem.