### PR TITLE
fix: LSP4E DeleteParticipant fails with FileSystemNotFoundException for custom EFS URI schemes

### DIFF
--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.19.14.qualifier
+Bundle-Version: 0.19.15.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.19.14-SNAPSHOT</version>
+	<version>0.19.15-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPFileOperationParticipantSupport.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/rename/LSPFileOperationParticipantSupport.java
@@ -111,13 +111,14 @@ public final class LSPFileOperationParticipantSupport {
 			final Function<FileOperationsServerCapabilities, @Nullable FileOperationOptions> optionsProvider) {
 		final var uri = LSPEclipseUtils.toUri(res);
 		final var project = res.getProject();
-		if (uri == null) {
-			// No URI means we cannot match any file operation filters; return an executor
+		if (uri == null || !"file".equalsIgnoreCase(uri.getScheme())) { //$NON-NLS-1$
+			// No URI or file scheme means we cannot match any file operation filters; return an executor
 			// that will not match any servers.
 			return LanguageServers.forProject(project).withFilter(capabilities -> false);
 		}
 
-		final var path = Path.of(uri);
+		final Path path = Path.of(uri);
+
 		return LanguageServers.forProject(project).withFilter(capabilities -> {
 			final var workspace = capabilities.getWorkspace();
 			if (workspace == null)


### PR DESCRIPTION
Fix for https://github.com/eclipse-lsp4e/lsp4e/issues/1559