### PR TITLE
fix(outline): avoid deep DocumentSymbol hashing on every outline refresh

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/SymbolsElementComparerTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/outline/SymbolsElementComparerTest.java
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vogella GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Lars Vogel (Vogella GmbH) - initial implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.test.outline;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.List;
+
+import org.eclipse.lsp4e.outline.SymbolsElementComparer;
+import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithURI;
+import org.eclipse.lsp4j.DocumentSymbol;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SymbolKind;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The fixture mirrors what vscode-json-languageserver returns for a nested
+ * array-of-objects document, where (name, kind) pairs repeat at several depths.
+ */
+public class SymbolsElementComparerTest {
+
+	private static final URI URI_A = URI.create("file:///a.json");
+	private static final URI URI_B = URI.create("file:///b.json");
+
+	private final SymbolsElementComparer comparer = new SymbolsElementComparer();
+
+	private static DocumentSymbol symbol(String name, SymbolKind kind, int line, int character) {
+		final var position = new Position(line, character);
+		// a deliberately wide full range, so tests that vary it prove it is not part of the key
+		return new DocumentSymbol(name, kind, new Range(position, new Position(line + 50, 0)),
+				new Range(position, new Position(line, character + name.length())));
+	}
+
+	/** items[0].id and items[1].id share name and kind, and differ only in position. */
+	@Test
+	public void testSameNameAndKindAtDifferentPositionsAreDistinct() {
+		final DocumentSymbol itemsZeroId = symbol("id", SymbolKind.Number, 3, 6);
+		final DocumentSymbol itemsOneId = symbol("id", SymbolKind.Number, 7, 6);
+
+		assertFalse(comparer.equals(itemsZeroId, itemsOneId));
+		assertNotEquals(comparer.hashCode(itemsZeroId), comparer.hashCode(itemsOneId));
+	}
+
+	/** items[0] and other[0] are both name="0" kind=Module, at different depths of the tree. */
+	@Test
+	public void testSameNameAndKindAtDifferentDepthsAreDistinct() {
+		final DocumentSymbol itemsZero = symbol("0", SymbolKind.Module, 2, 4);
+		final DocumentSymbol otherZero = symbol("0", SymbolKind.Module, 12, 4);
+
+		assertFalse(comparer.equals(itemsZero, otherZero));
+		assertNotEquals(comparer.hashCode(itemsZero), comparer.hashCode(otherZero));
+	}
+
+	/**
+	 * The whole point of the comparer: the key must not depend on the subtree, or
+	 * hashing recurses into every descendant.
+	 */
+	@Test
+	public void testChildrenAreNotPartOfTheKey() {
+		final DocumentSymbol withoutChildren = symbol("0", SymbolKind.Module, 2, 4);
+		final DocumentSymbol withChildren = symbol("0", SymbolKind.Module, 2, 4);
+		withChildren.setChildren(List.of(symbol("id", SymbolKind.Number, 3, 6), //
+				symbol("name", SymbolKind.String, 4, 6)));
+
+		assertTrue(comparer.equals(withoutChildren, withChildren));
+		assertEquals(comparer.hashCode(withoutChildren), comparer.hashCode(withChildren));
+	}
+
+	/**
+	 * The full range grows while typing inside the symbol body, so it must not be
+	 * part of the key, otherwise the edited symbol rehashes on every keystroke.
+	 */
+	@Test
+	public void testFullRangeIsNotPartOfTheKey() {
+		final DocumentSymbol before = symbol("items", SymbolKind.Array, 1, 2);
+		final DocumentSymbol afterTyping = symbol("items", SymbolKind.Array, 1, 2);
+		afterTyping.setRange(new Range(new Position(1, 2), new Position(999, 0)));
+
+		assertTrue(comparer.equals(before, afterTyping));
+		assertEquals(comparer.hashCode(before), comparer.hashCode(afterTyping));
+	}
+
+	/** The server returns fresh instances on every refresh, so identity must not be used. */
+	@Test
+	public void testStructurallyIdenticalSymbolsFromASecondRefreshMatch() {
+		final DocumentSymbol firstRefresh = symbol("items", SymbolKind.Array, 1, 2);
+		final DocumentSymbol secondRefresh = symbol("items", SymbolKind.Array, 1, 2);
+
+		assertTrue(comparer.equals(firstRefresh, secondRefresh));
+		assertEquals(comparer.hashCode(firstRefresh), comparer.hashCode(secondRefresh));
+	}
+
+	@Test
+	public void testDifferentKindsAreDistinct() {
+		final DocumentSymbol asNumber = symbol("id", SymbolKind.Number, 3, 6);
+		final DocumentSymbol asString = symbol("id", SymbolKind.String, 3, 6);
+
+		assertFalse(comparer.equals(asNumber, asString));
+	}
+
+	@Test
+	public void testWrappedSymbolsFromDifferentDocumentsAreDistinct() {
+		final DocumentSymbol symbol = symbol("items", SymbolKind.Array, 1, 2);
+		final var inA = new DocumentSymbolWithURI(symbol, URI_A);
+		final var inB = new DocumentSymbolWithURI(symbol, URI_B);
+
+		assertFalse(comparer.equals(inA, inB));
+		assertNotEquals(comparer.hashCode(inA), comparer.hashCode(inB));
+	}
+
+	@Test
+	public void testWrappedSymbolsAreMatchedByKey() {
+		final var firstRefresh = new DocumentSymbolWithURI(symbol("items", SymbolKind.Array, 1, 2), URI_A);
+		final var secondRefresh = new DocumentSymbolWithURI(symbol("items", SymbolKind.Array, 1, 2), URI_A);
+
+		assertTrue(comparer.equals(firstRefresh, secondRefresh));
+		assertEquals(comparer.hashCode(firstRefresh), comparer.hashCode(secondRefresh));
+	}
+
+	@Test
+	public void testUnwrappedAndWrappedSymbolsDoNotMatch() {
+		final DocumentSymbol symbol = symbol("items", SymbolKind.Array, 1, 2);
+
+		assertFalse(comparer.equals(symbol, new DocumentSymbolWithURI(symbol, URI_A)));
+	}
+
+	/** The tree also holds SymbolInformation and the outline input object. */
+	@Test
+	public void testUnknownElementTypesFallBackToTheirOwnEquality() {
+		assertTrue(comparer.equals("same", "same"));
+		assertFalse(comparer.equals("one", "other"));
+		assertEquals("same".hashCode(), comparer.hashCode("same"));
+	}
+
+	/**
+	 * The setters reject null, but gson writes the fields directly, so a malformed
+	 * server response can still produce a symbol without a selection range.
+	 */
+	private static DocumentSymbol deserializedWithoutSelectionRange(String name, SymbolKind kind) {
+		final var symbol = new DocumentSymbol();
+		symbol.setName(name);
+		symbol.setKind(kind);
+		return symbol;
+	}
+
+	@Test
+	public void testNullsAreTolerated() {
+		final DocumentSymbol withoutSelectionRange = deserializedWithoutSelectionRange("items", SymbolKind.Array);
+
+		assertTrue(comparer.equals(null, null));
+		assertFalse(comparer.equals(null, withoutSelectionRange));
+		assertFalse(comparer.equals(withoutSelectionRange, null));
+		assertEquals(0, comparer.hashCode(null));
+		// must not throw
+		comparer.hashCode(withoutSelectionRange);
+	}
+
+	@Test
+	public void testSymbolsWithoutSelectionRangeFallBackToNameAndKind() {
+		final DocumentSymbol one = deserializedWithoutSelectionRange("items", SymbolKind.Array);
+		final DocumentSymbol copy = deserializedWithoutSelectionRange("items", SymbolKind.Array);
+		final DocumentSymbol other = deserializedWithoutSelectionRange("other", SymbolKind.Array);
+
+		assertTrue(comparer.equals(one, copy));
+		assertEquals(comparer.hashCode(one), comparer.hashCode(copy));
+		assertFalse(comparer.equals(one, other));
+		assertFalse(comparer.equals(one, symbol("items", SymbolKind.Array, 1, 2)));
+	}
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
@@ -294,6 +294,9 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 
 		this.viewer = (TreeViewer) viewer;
 
+		// avoid the deep, subtree-recursive DocumentSymbol.hashCode/equals on every refresh
+		this.viewer.setComparer(new SymbolsElementComparer());
+
 		// this enables limiting the number of outline entries to mitigate UI freezes
 		WorkbenchViewerSetup.setupViewer(this.viewer);
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsElementComparer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/SymbolsElementComparer.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Vogella GmbH and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Lars Vogel (Vogella GmbH) - initial implementation
+ *******************************************************************************/
+package org.eclipse.lsp4e.outline;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jface.viewers.IElementComparer;
+import org.eclipse.lsp4e.outline.SymbolsModel.DocumentSymbolWithURI;
+import org.eclipse.lsp4j.DocumentSymbol;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+
+/**
+ * Identifies outline elements by name, kind and selection start instead of by
+ * value.
+ * <p>
+ * {@link DocumentSymbol#hashCode()} and {@link DocumentSymbol#equals(Object)}
+ * include the {@code children} list, so they walk the entire subtree. Tree
+ * viewers call both per element on every refresh, which makes a full outline
+ * refresh cost the sum of all subtree sizes.
+ */
+public final class SymbolsElementComparer implements IElementComparer {
+
+	@Override
+	public int hashCode(final @Nullable Object element) {
+		if (element instanceof DocumentSymbolWithURI symbolWithURI)
+			return 31 * hashCode(symbolWithURI.symbol) + symbolWithURI.uri.hashCode();
+		if (element instanceof DocumentSymbol symbol) {
+			final Position start = selectionStartOf(symbol);
+			return Objects.hash(symbol.getName(), symbol.getKind(), start);
+		}
+		return element == null ? 0 : element.hashCode();
+	}
+
+	@Override
+	public boolean equals(final @Nullable Object a, final @Nullable Object b) {
+		if (a == b)
+			return true;
+		if (a == null || b == null)
+			return false;
+		if (a instanceof DocumentSymbolWithURI symbolA && b instanceof DocumentSymbolWithURI symbolB)
+			return symbolA.uri.equals(symbolB.uri) && equals(symbolA.symbol, symbolB.symbol);
+		if (a instanceof DocumentSymbol symbolA && b instanceof DocumentSymbol symbolB)
+			return symbolA.getKind() == symbolB.getKind() //
+					&& Objects.equals(symbolA.getName(), symbolB.getName())
+					&& Objects.equals(selectionStartOf(symbolA), selectionStartOf(symbolB));
+		return a.equals(b);
+	}
+
+	/**
+	 * Uses the selection range rather than the full range, because the full range
+	 * grows while typing inside the symbol body.
+	 */
+	private static @Nullable Position selectionStartOf(final DocumentSymbol symbol) {
+		final Range selectionRange = symbol.getSelectionRange();
+		return selectionRange == null ? null : selectionRange.getStart();
+	}
+}


### PR DESCRIPTION
LSP4J generates `DocumentSymbol.hashCode()` and `equals()` over all fields including the children list, so both recurse over the whole subtree. The outline tree viewer calls them per element on every refresh, which makes a refresh cost the sum of all subtree sizes rather than O(1) per element. Profiling a 100,000 line JSON file in the Generic Editor showed 2 to 3.6 seconds of UI thread work per keystroke with the Outline view open, versus 35 to 49 ms with it closed, with 86% of busy UI samples in `DocumentSymbol.hashCode()` reached from `setExpandedTreePaths()`.

Setting an `IElementComparer` that identifies elements by name, kind and selection start fixes this without any JFace change, because JFace routes both the element map and `TreePath.hashCode()` through the comparer, neutralising the deep `hashCode` and the deep `equals` at once. After the change an open Outline view costs about the same as a closed one again, roughly 100 ms against a 99 ms closed-outline control. It is set on `LSSymbolsContentProvider`, so it covers both the Outline view and the Quick Outline.

The key includes the position because `(name, kind)` alone collides across the tree (`items/0/id` and `items/1/id` are both `name="id" kind=Number`), and `CommonViewer` forces `setUseHashlookup(true)`, so duplicate equal elements anywhere break element to item lookup. It uses the selection range rather than the full range because the full range grows while typing inside a symbol body.

Note this does not on its own make outlines of large files fast. The Common Navigator Framework keeps element keyed collections that ignore the viewer comparer and still hash symbols deeply on every refresh (`NavigatorContentService.contributionMemory` and `contributionMemoryFirstClass`, plus `ContributorTrackingSet`); those account for most of what remains and need a fix on the Platform side.