### PR TITLE
fix(outline): debounce outline refreshes on document changes

### DIFF
--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/outline/LSSymbolsContentProvider.java
@@ -32,7 +32,9 @@ import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ICoreRunnable;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.IPreferenceChangeListener;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences.PreferenceChangeEvent;
@@ -118,7 +120,12 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 
 	private final class DocumentChangedOutlineUpdater implements IDocumentListener, IOutlineUpdater {
 
+		/** matches the default delay of {@link AbstractReconciler} used by {@link ReconcilerOutlineUpdater} */
+		private static final int REFRESH_DELAY_MS = 500;
+
 		private final IDocument document;
+		private final Job refreshJob = Job.createSystem("Refresh Outline", //$NON-NLS-1$
+				(ICoreRunnable) monitor -> refreshTreeContentFromLS());
 
 		DocumentChangedOutlineUpdater(IDocument document) {
 			this.document = document;
@@ -133,6 +140,7 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 		@Override
 		public void uninstall() {
 			document.removeDocumentListener(this);
+			refreshJob.cancel();
 		}
 
 		@Override
@@ -142,7 +150,10 @@ public class LSSymbolsContentProvider implements ICommonContentProvider, ITreeCo
 
 		@Override
 		public void documentChanged(DocumentEvent event) {
-			refreshTreeContentFromLS();
+			// coalesce bursts of edits into a single request, one refresh per keystroke is
+			// far more than the language server or the tree can keep up with
+			refreshJob.cancel();
+			refreshJob.schedule(REFRESH_DELAY_MS);
 		}
 
 	}


### PR DESCRIPTION
`DocumentChangedOutlineUpdater` called `refreshTreeContentFromLS()` straight from `documentChanged()`, so every keystroke triggered a full `textDocument/documentSymbol` round trip plus a full tree refresh. On a 100,000 line JSON file that request alone costs about 650 ms of server CPU. This coalesces bursts of edits into a single refresh using a system job rescheduled on each change, with the same 500 ms delay that `AbstractReconciler` already applies on the `ReconcilerOutlineUpdater` path.

Worth being explicit about the scope: this is the fallback updater, used only when the editor exposes no `ITextViewer`. Editors that do, including the Generic Editor, already go through `ReconcilerOutlineUpdater` and its 500 ms delay, so this is not expected to show up in a Generic Editor measurement. It closes a real gap on the remaining path rather than fixing an observed regression there.

Independent of #1575, which addresses the much larger cost in the same area; the two touch different code paths and can merge in either order.