### PR TITLE
feat: Support active parameter in signature help

### DIFF
--- a/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for language server bundle (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.test;singleton:=true
-Bundle-Version: 0.16.13.qualifier
+Bundle-Version: 0.16.14.qualifier
 Fragment-Host: org.eclipse.lsp4e
 Bundle-Vendor: Eclipse LSP4E
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/org.eclipse.lsp4e.test/pom.xml
+++ b/org.eclipse.lsp4e.test/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.16.13-SNAPSHOT</version>
+	<version>0.16.14-SNAPSHOT</version>
 
 	<properties>
 		<os-jvm-flags /> <!-- for the default case -->

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompletionProposalToolsTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/CompletionProposalToolsTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
+package org.eclipse.lsp4e.test.completion;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.lsp4e.operations.completion.CompletionProposalTools;
+import org.eclipse.lsp4e.operations.completion.LocationInString;
+import org.eclipse.lsp4j.ParameterInformation;
+import org.eclipse.lsp4j.SignatureInformation;
+import org.eclipse.lsp4j.jsonrpc.messages.Tuple;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class CompletionProposalToolsTest {
+
+	public static final Stream<Arguments> getActiveParameter() {
+		SignatureInformation noActiveParameter = new SignatureInformation("(par1, par2)", "documentation",
+				List.of(new ParameterInformation("par1", "par1 doc"), new ParameterInformation("par2", "par2 doc")));
+
+		SignatureInformation invalidIndex = new SignatureInformation("(par1, par2)", "documentation",
+				List.of(new ParameterInformation("par1", "par1 doc"), new ParameterInformation("par2", "par2 doc")));
+		invalidIndex.setActiveParameter(2);
+
+		SignatureInformation validIndex = new SignatureInformation("(par1, par2)", "documentation",
+				List.of(new ParameterInformation("par1", "par1 doc"), new ParameterInformation("par2", "par2 doc")));
+		validIndex.setActiveParameter(1);
+
+		SignatureInformation validIndexButNotPresentInSignature = new SignatureInformation("(par1, foobar2)",
+				"documentation",
+				List.of(new ParameterInformation("par1", "par1 doc"), new ParameterInformation("par2", "par2 doc")));
+		validIndexButNotPresentInSignature.setActiveParameter(1);
+
+		ParameterInformation par2 = new ParameterInformation();
+		par2.setLabel(Tuple.two(7, 11));
+		SignatureInformation activeLocationGivenByTuple = new SignatureInformation("(par1, par2)", "documentation",
+				List.of(new ParameterInformation("par1", "par1 doc"), par2));
+		activeLocationGivenByTuple.setActiveParameter(1);
+
+		return Stream.of(Arguments.of(noActiveParameter, null), Arguments.of(invalidIndex, null),
+				Arguments.of(validIndex, new LocationInString(7, 4)),
+				Arguments.of(validIndexButNotPresentInSignature, null),
+				Arguments.of(activeLocationGivenByTuple, new LocationInString(7, 4)));
+	}
+
+	@ParameterizedTest
+	@MethodSource
+	void getActiveParameter(SignatureInformation info, LocationInString activeParameter) throws Exception {
+		assertEquals(activeParameter, CompletionProposalTools.extractActiveParameter(info));
+	}
+
+}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/ContextInformationTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/completion/ContextInformationTest.java
@@ -13,10 +13,13 @@ package org.eclipse.lsp4e.test.completion;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
@@ -24,9 +27,15 @@ import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.operations.completion.LSContentAssistProcessor;
+import org.eclipse.lsp4e.operations.completion.LSContextInformation;
+import org.eclipse.lsp4e.operations.completion.LSContextInformationValidator;
 import org.eclipse.lsp4e.test.utils.TestUtils;
+import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServerFactory;
+import org.eclipse.lsp4e.tests.mock.MockTextDocumentService;
+import org.eclipse.lsp4j.ParameterInformation;
 import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SignatureHelpParams;
 import org.eclipse.lsp4j.SignatureInformation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,6 +80,72 @@ public class ContextInformationTest extends AbstractCompletionTest {
 				.append(LSPEclipseUtils.getDocString(information.getDocumentation()))
 				.toString();
 		assertEquals(expected, infos[0].getInformationDisplayString());
+	}
+	
+	@Test
+	public void testContextInformationWithActiveParameter(MockLanguageServerFactory factory) throws CoreException {
+		factory.withConfiguration((idx, server) -> {
+			server.setTextDocumentService(createDocumentServiceWithSignatureHelp(server));
+		});
+
+		IFile testFile = TestUtils.createUniqueTestFile(project, "func(arg1, arg2)");
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
+
+		IContextInformation[] infos = contentAssistProcessor.computeContextInformation(viewer, 10);
+		assertEquals(1, infos.length);
+		LSContextInformation lsInfo = (LSContextInformation) infos[0];
+
+		// 'par2' is the active parameter
+		assertEquals(7, lsInfo.getActiveParameter().start());
+		assertEquals(4, lsInfo.getActiveParameter().length());
+	}
+
+	@Test
+	public void testContextInformationValidationUpdatesActiveParameter(MockLanguageServerFactory factory) throws CoreException {
+		factory.withConfiguration((idx, server) -> {
+			server.setTextDocumentService(createDocumentServiceWithSignatureHelp(server));
+		});
+
+		IFile testFile = TestUtils.createUniqueTestFile(project, "func(arg1, arg2)");
+		ITextViewer viewer = TestUtils.openTextViewer(testFile);
+
+		IContextInformation[] infos = contentAssistProcessor.computeContextInformation(viewer, 5);
+		assertEquals(1, infos.length);
+		LSContextInformation lsInfo = (LSContextInformation) infos[0];
+
+		LSContextInformationValidator validator = new LSContextInformationValidator(contentAssistProcessor);
+		validator.install(lsInfo, viewer, 5);
+		assertTrue(validator.isContextInformationValid(5));
+		assertEquals(1, lsInfo.getActiveParameter().start());
+
+		assertTrue(validator.isContextInformationValid(10));
+		assertEquals(7, lsInfo.getActiveParameter().start());
+
+		assertFalse(validator.isContextInformationValid(15));
+	}
+
+	private MockTextDocumentService createDocumentServiceWithSignatureHelp(MockLanguageServer server) {
+		return new MockTextDocumentService(server::buildMaybeDelayedFuture) {
+			@Override
+			public CompletableFuture<SignatureHelp> signatureHelp(SignatureHelpParams position) {
+				final var signatureHelp = new SignatureHelp();
+				final var information = new SignatureInformation("(par1, par2)", "documentation", List.of(
+						new ParameterInformation("par1", "par1 doc"), new ParameterInformation("par2", "par2 doc")));
+				int pos = position.getPosition().getCharacter();
+				if (pos >= 5 && pos < 9) {
+					// in 'arg1'
+					information.setActiveParameter(0);
+				} else if (pos >= 9 && pos < 15) {
+					// in ', arg2'
+					information.setActiveParameter(1);
+				} else {
+					// Not in signature
+					return CompletableFuture.completedFuture(signatureHelp);
+				}
+				signatureHelp.setSignatures(List.of(information));
+				return CompletableFuture.completedFuture(signatureHelp);
+			}
+		};
 	}
 
 	@Test

--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.19.14.qualifier
+Bundle-Version: 0.19.15.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.19.14-SNAPSHOT</version>
+	<version>0.19.15-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/SupportedFeatures.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/SupportedFeatures.java
@@ -46,6 +46,7 @@ import org.eclipse.lsp4j.InlayHintCapabilities;
 import org.eclipse.lsp4j.InsertTextMode;
 import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.OnTypeFormattingCapabilities;
+import org.eclipse.lsp4j.ParameterInformationCapabilities;
 import org.eclipse.lsp4j.PublishDiagnosticsCapabilities;
 import org.eclipse.lsp4j.RangeFormattingCapabilities;
 import org.eclipse.lsp4j.ReferencesCapabilities;
@@ -54,6 +55,7 @@ import org.eclipse.lsp4j.ResourceOperationKind;
 import org.eclipse.lsp4j.SelectionRangeCapabilities;
 import org.eclipse.lsp4j.ShowDocumentCapabilities;
 import org.eclipse.lsp4j.SignatureHelpCapabilities;
+import org.eclipse.lsp4j.SignatureInformationCapabilities;
 import org.eclipse.lsp4j.SymbolCapabilities;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.SymbolKindCapabilities;
@@ -144,7 +146,15 @@ public class SupportedFeatures {
 		final var renameCapabilities = new RenameCapabilities();
 		renameCapabilities.setPrepareSupport(true);
 		textDocumentClientCapabilities.setRename(renameCapabilities);
-		textDocumentClientCapabilities.setSignatureHelp(new SignatureHelpCapabilities());
+
+		SignatureHelpCapabilities signatureHelpCapabilities = new SignatureHelpCapabilities();
+		SignatureInformationCapabilities signatureInformationCapabilities = new SignatureInformationCapabilities(
+				List.of(MarkupKind.PLAINTEXT, MarkupKind.MARKDOWN));
+		signatureInformationCapabilities.setActiveParameterSupport(true);
+		signatureInformationCapabilities.setParameterInformation(new ParameterInformationCapabilities(true));
+		signatureHelpCapabilities.setSignatureInformation(signatureInformationCapabilities);
+
+		textDocumentClientCapabilities.setSignatureHelp(signatureHelpCapabilities);
 		textDocumentClientCapabilities.setSynchronization(new SynchronizationCapabilities(true, true, true));
 		final var selectionRange = new SelectionRangeCapabilities();
 		textDocumentClientCapabilities.setSelectionRange(selectionRange);

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/CompletionProposalTools.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/CompletionProposalTools.java
@@ -11,8 +11,13 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.operations.completion;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.lsp4j.ParameterInformation;
+import org.eclipse.lsp4j.SignatureInformation;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.jsonrpc.messages.Tuple.Two;
 
 public final class CompletionProposalTools {
 
@@ -200,4 +205,33 @@ public final class CompletionProposalTools {
 		}
 		return i;
 	}
+
+	/**
+	 * Extract the location of the active parameter from the given signature information.
+	 * The returned {@link LocationInString} describes the start index and length of the active parameter in the signature label.
+	 * @param information
+	 * @return
+	 */
+	public static @Nullable LocationInString extractActiveParameter(SignatureInformation information) {
+		if (information.getActiveParameter() instanceof Integer active && information.getParameters() != null
+				&& active >= 0 && active < information.getParameters().size()) {
+			ParameterInformation parameterInformation = information.getParameters().get(active);
+			Either<String, Two<Integer, Integer>> labelInfo = parameterInformation.getLabel();
+			if (labelInfo.isLeft()) {
+				String label = information.getLabel();
+				String activeName = labelInfo.getLeft();
+				int start = label.indexOf(activeName);
+				if (start == -1) {
+					// Given parameter is not present in signature
+					return null;
+				}
+				return new LocationInString(start, activeName.length());
+			} else if (labelInfo.isRight()) {
+				Two<Integer, Integer> startEnd = labelInfo.getRight();
+				return new LocationInString(startEnd.getFirst(), startEnd.getSecond() - startEnd.getFirst());
+			}
+		}
+		return null;
+	}
+
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
@@ -806,7 +806,7 @@ public class LSCompletionProposal
 
 	@Override
 	public @Nullable IContextInformation getContextInformation() {
-		return this;
+		return null;
 	}
 
 	@Override

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSContentAssistProcessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSContentAssistProcessor.java
@@ -37,8 +37,6 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.contentassist.CompletionProposal;
-import org.eclipse.jface.text.contentassist.ContextInformation;
-import org.eclipse.jface.text.contentassist.ContextInformationValidator;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.jface.text.contentassist.IContentAssistProcessor;
 import org.eclipse.jface.text.contentassist.IContextInformation;
@@ -340,7 +338,9 @@ public class LSContentAssistProcessor implements IContentAssistProcessor {
 		if (docString != null && !docString.isEmpty()) {
 			signature.append('\n').append(docString);
 		}
-		return new ContextInformation(information.getLabel(), signature.toString());
+
+		LocationInString activeParameter = CompletionProposalTools.extractActiveParameter(information);
+		return new LSContextInformation(information.getLabel(), signature.toString(), activeParameter);
 	}
 
 	private void getFuture(@Nullable CompletableFuture<?> future) {
@@ -408,6 +408,6 @@ public class LSContentAssistProcessor implements IContentAssistProcessor {
 
 	@Override
 	public @Nullable IContextInformationValidator getContextInformationValidator() {
-		return new ContextInformationValidator(this);
+		return new LSContextInformationValidator(this);
 	}
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSContextInformation.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSContextInformation.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
+package org.eclipse.lsp4e.operations.completion;
+
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jface.text.contentassist.IContextInformation;
+import org.eclipse.swt.graphics.Image;
+
+public final class LSContextInformation implements IContextInformation {
+
+	private final String contextDisplayString;
+	private final String informationDisplayString;
+	/**
+	 * The location of the active parameter in the signature.
+	 */
+	private @Nullable LocationInString activeParameter;
+
+	public LSContextInformation(String contextDisplayString, String informationDisplayString,
+			@Nullable LocationInString activeParameter) {
+		this.contextDisplayString = contextDisplayString;
+		this.informationDisplayString = informationDisplayString;
+		this.activeParameter = activeParameter;
+	}
+
+	@Override
+	public String getContextDisplayString() {
+		return contextDisplayString;
+	}
+
+	@Override
+	public String getInformationDisplayString() {
+		return informationDisplayString;
+	}
+
+	/**
+	 * Get the location of the active parameter in the signature.
+	 */
+	public @Nullable LocationInString getActiveParameter() {
+		return activeParameter;
+	}
+
+	/**
+	 * Set the location of the active parameter in the signature.
+	 *
+	 * @param activeParameter
+	 */
+	public void setActiveParameter(@Nullable LocationInString activeParameter) {
+		this.activeParameter = activeParameter;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(contextDisplayString, informationDisplayString);
+	}
+
+	@Override
+	public boolean equals(@Nullable Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		LSContextInformation other = (LSContextInformation) obj;
+		return Objects.equals(contextDisplayString, other.contextDisplayString)
+				&& Objects.equals(informationDisplayString, other.informationDisplayString);
+	}
+
+	@Override
+	public @Nullable Image getImage() {
+		return null;
+	}
+
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSContextInformationValidator.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSContextInformationValidator.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   See git history
+ *******************************************************************************/
+package org.eclipse.lsp4e.operations.completion;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.TextPresentation;
+import org.eclipse.jface.text.contentassist.IContentAssistProcessor;
+import org.eclipse.jface.text.contentassist.IContextInformation;
+import org.eclipse.jface.text.contentassist.IContextInformationPresenter;
+import org.eclipse.jface.text.contentassist.IContextInformationValidator;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.StyleRange;
+
+public final class LSContextInformationValidator implements IContextInformationValidator, IContextInformationPresenter {
+
+	/** The content assist processor. */
+	private final IContentAssistProcessor fProcessor;
+	/** The context information to be validated. */
+	private @Nullable IContextInformation fContextInformation;
+	/** The associated text viewer. */
+	private @Nullable ITextViewer fViewer;
+
+	/**
+	 * Creates a new context information validator which is ready to be installed on
+	 * a particular context information.
+	 *
+	 * @param processor
+	 *            the processor to be used for validation
+	 */
+	public LSContextInformationValidator(IContentAssistProcessor processor) {
+		fProcessor = processor;
+	}
+
+	@Override
+	public void install(@Nullable IContextInformation contextInformation, @Nullable ITextViewer viewer, int offset) {
+		fContextInformation = contextInformation;
+		fViewer = viewer;
+	}
+
+	@Override
+	public boolean isContextInformationValid(int offset) {
+		if (!(fViewer instanceof ITextViewer viewer)) {
+			return false;
+		}
+		if (!(fContextInformation instanceof LSContextInformation contextInfo)) {
+			return false;
+		}
+
+		// Check if the current context information is still valid for the given offset.
+		IContextInformation[] infos = fProcessor.computeContextInformation(viewer, offset);
+		if (infos != null) {
+			for (IContextInformation info : infos) {
+				if (contextInfo.equals(info)) {
+					// Grab active parameter from new context.
+					contextInfo.setActiveParameter(((LSContextInformation) info).getActiveParameter());
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean updatePresentation(int offset, @Nullable TextPresentation presentation) {
+		if (presentation == null) {
+			return false;
+		}
+		if (!(fContextInformation instanceof LSContextInformation contextInfo)) {
+			return false;
+		}
+
+		/*
+		 * Assumption: The context information has been validated before this call
+		 * and the active parameter has been updated accordingly.
+		 */
+		presentation.clear();
+		if (contextInfo.getActiveParameter() instanceof LocationInString location) {
+			presentation.addStyleRange(new StyleRange(location.start(), location.length(), null, null, SWT.BOLD));
+		}
+		return true;
+	}
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LocationInString.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LocationInString.java
@@ -1,0 +1,8 @@
+package org.eclipse.lsp4e.operations.completion;
+
+/**
+ * Describes a location in a string by its start index and length.
+ */
+public record LocationInString(int start, int length) {
+
+}


### PR DESCRIPTION
+ Introduce `LSContextInformation` to hold information about currently active parameter
+ Introduce `LSContextInformationValidator` to update active parameter when cursor moves and update styling of displayed context info
+ `LSCompletionProposal` no longer returns itself as `IContextInformation`. I think this behavior is wrong in the context of LSP, because completions don't have knowledge about their signature help.
+ Add a few test cases
