### PR TITLE
Dynamic codeactions registration

### DIFF
--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/codeactions/CodeActionTests.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/codeactions/CodeActionTests.java
@@ -269,11 +269,11 @@ public class CodeActionTests extends AbstractTestWithProject {
 		assertEquals(new FileEditorInput(targetFile), ((AbstractTextEditor)activeEditorPart).getEditorInput());
 	}
 
-	private static IMarker assertDiagnostics(IFile f, String markerMessage, String resolutionLabel) throws CoreException {
+	public static IMarker assertDiagnostics(IFile f, String markerMessage, String resolutionLabel) throws CoreException {
 		return assertDiagnostics(f, markerMessage, resolutionLabel, true);
 	}
 
-	private static IMarker assertDiagnostics(IFile f, String markerMessage, String resolutionLabel, boolean resolutionExpected) throws CoreException {
+	public static IMarker assertDiagnostics(IFile f, String markerMessage, String resolutionLabel, boolean resolutionExpected) throws CoreException {
 		waitForAndAssertCondition(2_000, () -> {
 			IMarker[] markers = f.findMarkers(LSPDiagnosticsToMarkers.LS_DIAGNOSTIC_MARKER_TYPE, true,
 					IResource.DEPTH_ZERO);
@@ -294,7 +294,7 @@ public class CodeActionTests extends AbstractTestWithProject {
 		return m;
 	}
 
-	private static void assertResolution(AbstractTextEditor editor, IMarker m, String newText) {
+	public static void assertResolution(AbstractTextEditor editor, IMarker m, String newText) {
 		IDE.getMarkerHelpRegistry().getResolutions(m)[0].run(m);
 
 		waitForCondition(1_000,

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/commands/DynamicRegistrationTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/commands/DynamicRegistrationTest.java
@@ -12,36 +12,53 @@
 package org.eclipse.lsp4e.test.commands;
 
 import static org.eclipse.lsp4e.test.utils.TestUtils.waitForCondition;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IMarker;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServers;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
+import org.eclipse.lsp4e.test.codeactions.CodeActionTests;
 import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServerFactory;
 import org.eclipse.lsp4e.tests.mock.MockWorkspaceService;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.CodeActionOptions;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
 import org.eclipse.lsp4j.FileChangeType;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.Registration;
 import org.eclipse.lsp4j.RegistrationParams;
 import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.Unregistration;
 import org.eclipse.lsp4j.UnregistrationParams;
+import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.WorkspaceFoldersOptions;
 import org.eclipse.lsp4j.WorkspaceServerCapabilities;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.ui.texteditor.AbstractTextEditor;
 import org.junit.jupiter.api.Test;
 
 public class DynamicRegistrationTest extends AbstractTestWithProject {
@@ -49,7 +66,7 @@ public class DynamicRegistrationTest extends AbstractTestWithProject {
 	private static final String WORKSPACE_EXECUTE_COMMAND = "workspace/executeCommand";
 	private static final String WORKSPACE_DID_CHANGE_FOLDERS = "workspace/didChangeWorkspaceFolders";
 	private static final String WORKSPACE_DID_CHANGE_WATCHED_FILES = "workspace/didChangeWatchedFiles";
-
+	private static final String CODE_ACTION = "textDocument/codeAction";
 	@Test
 	public void testCommandRegistration(MockLanguageServerFactory factory) throws Exception {
 		IFile testFile = TestUtils.createFile(project, "shouldUseExtension.lspt", "");
@@ -73,6 +90,77 @@ public class DynamicRegistrationTest extends AbstractTestWithProject {
 		}
 		assertFalse(LanguageServiceAccessor.hasActiveLanguageServers(handlesCommand("test.command")));
 		assertFalse(LanguageServiceAccessor.hasActiveLanguageServers(handlesCommand("test.command.2")));
+	}
+	
+	@Test
+	public void testDynamicCodeActionRegistration(MockLanguageServerFactory factory) throws Exception {
+		final var testFile = TestUtils.createFile(project, "shouldUseExtension.lspt", "");
+		final var resolveCount = new AtomicInteger(0);
+
+		final var staticCapabilities = MockLanguageServer.defaultServerCapabilities();
+		staticCapabilities.setCodeActionProvider(Boolean.FALSE);
+		factory.withCapabilities(() -> staticCapabilities);
+		factory.withConfiguration((idx, server)-> {
+			server.getTextDocumentService().setCodeActionResolver(action -> {
+				resolveCount.incrementAndGet();
+				return action;
+			});
+			
+			final var tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
+			final var wEdit = new WorkspaceEdit(Collections.singletonMap(testFile.getLocationURI().toString(), List.of(tEdit)));
+			final var codeAction = new CodeAction("fixme");
+			codeAction.setCommand(new Command("editCommand", "mockEditCommand", List.of(wEdit)));
+			server.setCodeActions(List.of(Either.forRight(codeAction)));
+			server.setDiagnostics(List.of(
+					new Diagnostic(new Range(new Position(0, 0), new Position(0, 5)), "error", DiagnosticSeverity.Error, null)));
+
+		});
+		
+		// Make sure mock language server is created...
+		final var document = LSPEclipseUtils.getDocument(testFile);
+		assertNotNull(document);
+		LanguageServers.forDocument(document).anyMatching();
+		
+		waitForCondition(5_000, () -> !factory.getServers().isEmpty());
+		assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(c -> true));
+		assertFalse(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActions()));
+		
+		final var codeActionOptions = new CodeActionOptions();
+		codeActionOptions.setCodeActionKinds(List.of(CodeActionKind.QuickFix, CodeActionKind.Refactor));
+		codeActionOptions.setResolveProvider(Boolean.FALSE);
+		
+		final UUID firstRegistration = registerCodeActionProvider(factory.getServer(), Either.forRight(codeActionOptions));
+		waitForCondition(5_000, () -> LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActions()));
+		
+		assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActions(options -> {
+			return options.getCodeActionKinds().containsAll(List.of(CodeActionKind.QuickFix, CodeActionKind.Refactor))
+					&& Boolean.FALSE.equals(options.getResolveProvider());
+		})));
+		
+
+		final var editor = (AbstractTextEditor)TestUtils.openEditor(testFile);
+		IMarker m = CodeActionTests.assertDiagnostics(testFile, "error", "fixme");
+		CodeActionTests.assertResolution(editor, m, "fixed");
+		
+		// Our dynamic registration specifies we don't support the codeAction/resolve method
+		assertEquals(0, resolveCount.get());
+		
+		// Now restore the static state (doesn't handle code actions)
+		TestUtils.closeEditor(editor, false);
+		unregister(firstRegistration, CODE_ACTION, factory.getServer());
+		waitForCondition(5_000, () -> !LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActions()));
+
+		codeActionOptions.setResolveProvider(true);
+		@SuppressWarnings("unused")
+		final UUID secondRegistration = registerCodeActionProvider(factory.getServer(), Either.forRight(codeActionOptions));
+		waitForCondition(5_000, () -> LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActions()));
+		
+		final var editor2 = (AbstractTextEditor)TestUtils.openEditor(testFile);
+		IMarker m2 = CodeActionTests.assertDiagnostics(testFile, "error", "fixme");
+		CodeActionTests.assertResolution(editor2, m2, "fixed");
+		
+		// We now support the codeAction/resolve method
+		assertEquals(1, resolveCount.get());
 	}
 
 	@Test
@@ -176,11 +264,37 @@ public class DynamicRegistrationTest extends AbstractTestWithProject {
 		client.registerCapability(new RegistrationParams(List.of(registration))).get(1, TimeUnit.SECONDS);
 		return id;
 	}
+	
+	private UUID registerCodeActionProvider(MockLanguageServer server, Either<Boolean, CodeActionOptions> options) throws Exception {
+		UUID id = UUID.randomUUID();
+		LanguageClient client = server.getRemoteProxy();
+		final var registration = new Registration();
+		registration.setId(id.toString());
+		registration.setMethod(CODE_ACTION);
+		registration.setRegisterOptions(options);
+		client.registerCapability(new RegistrationParams(List.of(registration))).get(1, TimeUnit.SECONDS);
+
+		return id;
+	}
 
 	private Predicate<ServerCapabilities> handlesCommand(String command) {
 		return cap -> {
 			ExecuteCommandOptions commandProvider = cap.getExecuteCommandProvider();
 			return commandProvider != null && commandProvider.getCommands().contains(command);
+		};
+	}
+	
+	private Predicate<ServerCapabilities> handlesCodeActions() {
+		return cap -> {
+			final var codeActionCaps = cap.getCodeActionProvider();
+			return codeActionCaps.isRight() || codeActionCaps.getLeft() ;
+		};
+	}
+	
+	private Predicate<ServerCapabilities> handlesCodeActions(Predicate<CodeActionOptions> options) {
+		return cap -> {
+			final var codeActionCaps = cap.getCodeActionProvider();
+			return codeActionCaps.isRight() && options.test(codeActionCaps.getRight());
 		};
 	}
 

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/internal/JsonUtilTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/internal/JsonUtilTest.java
@@ -12,9 +12,15 @@
 package org.eclipse.lsp4e.test.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
 
 import org.eclipse.lsp4e.internal.JsonUtil;
+import org.eclipse.lsp4j.CodeActionOptions;
 import org.eclipse.lsp4j.FileSystemWatcher;
+import org.eclipse.lsp4j.Registration;
 import org.eclipse.lsp4j.WatchKind;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +40,40 @@ public class JsonUtilTest {
 		
 		FileSystemWatcher copy = JsonUtil.LSP4J_GSON.fromJson(json, FileSystemWatcher.class);
 		assertEquals(original, copy);
+	}
+	
+	@Test
+	void testCodeActionUnserialization() throws Exception {
+		var original = new Registration();
+		original.setId("abc123");
+		original.setMethod("");
+		
+		// Set up a registration with the CodeActionOptions branch of the Boolean | CodeActionOptions payload
+		var options = new CodeActionOptions();
+		options.setCodeActionKinds(List.of("Action1", "Action2"));
+		options.setResolveProvider(Boolean.FALSE);
+		
+		original.setRegisterOptions(options);
+		
+		String json = JsonUtil.LSP4J_GSON.toJson(original);
+		
+		var back = JsonUtil.LSP4J_GSON.fromJson(json, Registration.class);
+		assertEquals(back.getId(), "abc123");
+				
+		var optionsBack = JsonUtil.unserializeCodeActionRegistration(back);
+		assertTrue(optionsBack.isRight());
+		var actionKinds = optionsBack.getRight().getCodeActionKinds();
+		assertEquals(actionKinds.size(), 2);
+		assertEquals(actionKinds.get(0), "Action1");
+		assertFalse(optionsBack.getRight().getResolveProvider());
+		
+		// Set up a registration with the simple boolean branch
+		original.setRegisterOptions(Boolean.FALSE);
+		json = JsonUtil.LSP4J_GSON.toJson(original);
+		back = JsonUtil.LSP4J_GSON.fromJson(json, Registration.class);
+		optionsBack = JsonUtil.unserializeCodeActionRegistration(back);
+		assertTrue(optionsBack.isLeft());
+		assertFalse(optionsBack.getLeft());
 	}
 
 }

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockTextDocumentService.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockTextDocumentService.java
@@ -93,6 +93,8 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either3;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.TextDocumentService;
 
+import com.google.common.base.Functions;
+
 public class MockTextDocumentService implements TextDocumentService {
 
 	private CompletionList mockCompletionList;
@@ -120,6 +122,7 @@ public class MockTextDocumentService implements TextDocumentService {
 	private Location[] mockReferences = new Location[0];
 	private List<Diagnostic> diagnostics;
 	private List<Either<Command, CodeAction>> mockCodeActions;
+	private Function<CodeAction, CodeAction> codeActionResolver = Functions.identity();
 	private List<ColorInformation> mockDocumentColors;
 	private WorkspaceEdit mockRenameEdit;
 	private Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior> mockPrepareRenameResult;
@@ -336,7 +339,7 @@ public class MockTextDocumentService implements TextDocumentService {
 
 	@Override
 	public CompletableFuture<CodeAction> resolveCodeAction(CodeAction unresolved) {
-		return CompletableFuture.completedFuture(unresolved);
+		return CompletableFuture.completedFuture(this.codeActionResolver.apply(unresolved));
 	}
 
 	public void setMockCompletionList(CompletionList completionList) {
@@ -397,6 +400,10 @@ public class MockTextDocumentService implements TextDocumentService {
 
 	public void setCodeActions(List<Either<Command, CodeAction>> codeActions) {
 		this.mockCodeActions = codeActions;
+	}
+
+	public void setCodeActionResolver(Function<CodeAction, CodeAction> resolver) {
+		this.codeActionResolver = resolver;
 	}
 
 	public void setSignatureHelp(SignatureHelp signatureHelp) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -1219,6 +1219,13 @@ public class LanguageServerWrapper {
 			case "textDocument/codeAction": //$NON-NLS-1$
 				final Either<Boolean, CodeActionOptions> beforeRegistration = serverCapabilities.getCodeActionProvider();
 				serverCapabilities.setCodeActionProvider(Boolean.TRUE);
+
+				try {
+					final var options = JsonUtil.unserializeCodeActionRegistration(reg);
+					serverCapabilities.setCodeActionProvider(options);
+				} catch (Exception ex) {
+					LanguageServerPlugin.logError(ex);
+				}
 				addRegistration(reg, () -> serverCapabilities.setCodeActionProvider(beforeRegistration));
 				break;
 			case "textDocument/completion": { //$NON-NLS-1$

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/JsonUtil.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/JsonUtil.java
@@ -14,9 +14,15 @@ package org.eclipse.lsp4e.internal;
 import java.util.Map;
 import java.util.Objects;
 
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.lsp4j.CodeActionOptions;
+import org.eclipse.lsp4j.Registration;
 import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
+import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 
 /**
  * Provides a {@link Gson} instance which can properly serialize and deserialize LSP4J JSON-RPC objects
@@ -24,5 +30,22 @@ import com.google.gson.Gson;
 public class JsonUtil {
 
 	public static final Gson LSP4J_GSON = Objects.requireNonNull(new MessageJsonHandler(Map.of()).getGson());
+
+
+	/**
+	 * Helper for dynamic registration: if the payload is a top-level Either then we can't
+	 * just pass Either.class to GSON, we need to use TypeTokens to avoid type erasure
+	 * @param registration
+	 * @return
+	 * @throws Exception
+	 */
+	@SuppressWarnings({ "unchecked", "null" })
+	public static @Nullable Either<Boolean, CodeActionOptions> unserializeCodeActionRegistration(Registration registration) throws Exception {
+		TypeToken<Either<Boolean, CodeActionOptions>> type = new TypeToken<Either<Boolean, CodeActionOptions>>() {};
+		var payload = (JsonElement)registration.getRegisterOptions();
+
+		return (Either<Boolean, CodeActionOptions>)LSP4J_GSON.fromJson(payload, type.getType());
+
+	}
 
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionCompletionProposal.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionCompletionProposal.java
@@ -49,14 +49,7 @@ public class CodeActionCompletionProposal implements ICompletionProposal {
 	static boolean isCodeActionResolveSupported(@Nullable ServerCapabilities capabilities) {
 		if (capabilities != null) {
 			Either<Boolean, CodeActionOptions> caProvider = capabilities.getCodeActionProvider();
-			if (caProvider.isLeft()) {
-				return caProvider.getLeft();
-			} else if (caProvider.isRight()) {
-				CodeActionOptions options = caProvider.getRight();
-				var resolveProvider = options.getResolveProvider();
-				if (resolveProvider != null)
-					return resolveProvider;
-			}
+			return caProvider.isRight() && Boolean.TRUE.equals(caProvider.getRight().getResolveProvider());
 		}
 		return false;
 	}


### PR DESCRIPTION
Draft fix for https://github.com/eclipse-lsp4e/lsp4e/issues/1565

 - Store the fine-grained server payload for dynamic registration of code actions
 - Only assume the server supports `codeAction/resolve` if explicitly marked as supported

Had to add some support logic for tests, but also to help with the slightly fiddly unserialization.
