### PR TITLE
Dynamic registration: recompute effective capabilities instead of pat…

### DIFF
--- a/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for language server bundle (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e.test;singleton:=true
-Bundle-Version: 0.16.14.qualifier
+Bundle-Version: 0.16.15.qualifier
 Fragment-Host: org.eclipse.lsp4e
 Bundle-Vendor: Eclipse LSP4E
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/org.eclipse.lsp4e.test/pom.xml
+++ b/org.eclipse.lsp4e.test/pom.xml
@@ -8,7 +8,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e.test</artifactId>
 	<packaging>eclipse-test-plugin</packaging>
-	<version>0.16.14-SNAPSHOT</version>
+	<version>0.16.15-SNAPSHOT</version>
 
 	<properties>
 		<os-jvm-flags /> <!-- for the default case -->

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/codeactions/CodeActionTests.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/codeactions/CodeActionTests.java
@@ -269,11 +269,11 @@ public class CodeActionTests extends AbstractTestWithProject {
 		assertEquals(new FileEditorInput(targetFile), ((AbstractTextEditor)activeEditorPart).getEditorInput());
 	}
 
-	private static IMarker assertDiagnostics(IFile f, String markerMessage, String resolutionLabel) throws CoreException {
+	public static IMarker assertDiagnostics(IFile f, String markerMessage, String resolutionLabel) throws CoreException {
 		return assertDiagnostics(f, markerMessage, resolutionLabel, true);
 	}
 
-	private static IMarker assertDiagnostics(IFile f, String markerMessage, String resolutionLabel, boolean resolutionExpected) throws CoreException {
+	public static IMarker assertDiagnostics(IFile f, String markerMessage, String resolutionLabel, boolean resolutionExpected) throws CoreException {
 		waitForAndAssertCondition(2_000, () -> {
 			IMarker[] markers = f.findMarkers(LSPDiagnosticsToMarkers.LS_DIAGNOSTIC_MARKER_TYPE, true,
 					IResource.DEPTH_ZERO);
@@ -294,7 +294,7 @@ public class CodeActionTests extends AbstractTestWithProject {
 		return m;
 	}
 
-	private static void assertResolution(AbstractTextEditor editor, IMarker m, String newText) {
+	public static void assertResolution(AbstractTextEditor editor, IMarker m, String newText) {
 		IDE.getMarkerHelpRegistry().getResolutions(m)[0].run(m);
 
 		waitForCondition(1_000,

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/commands/DynamicRegistrationTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/commands/DynamicRegistrationTest.java
@@ -12,36 +12,55 @@
 package org.eclipse.lsp4e.test.commands;
 
 import static org.eclipse.lsp4e.test.utils.TestUtils.waitForCondition;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IMarker;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServers;
 import org.eclipse.lsp4e.LanguageServiceAccessor;
+import org.eclipse.lsp4e.test.codeactions.CodeActionTests;
 import org.eclipse.lsp4e.test.utils.AbstractTestWithProject;
 import org.eclipse.lsp4e.test.utils.TestUtils;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServer;
 import org.eclipse.lsp4e.tests.mock.MockLanguageServerFactory;
 import org.eclipse.lsp4e.tests.mock.MockWorkspaceService;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.CodeActionOptions;
+import org.eclipse.lsp4j.CodeActionRegistrationOptions;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
 import org.eclipse.lsp4j.FileChangeType;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.Registration;
 import org.eclipse.lsp4j.RegistrationParams;
 import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.Unregistration;
 import org.eclipse.lsp4j.UnregistrationParams;
+import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.WorkspaceFoldersOptions;
 import org.eclipse.lsp4j.WorkspaceServerCapabilities;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.ui.texteditor.AbstractTextEditor;
 import org.junit.jupiter.api.Test;
 
 public class DynamicRegistrationTest extends AbstractTestWithProject {
@@ -49,6 +68,7 @@ public class DynamicRegistrationTest extends AbstractTestWithProject {
 	private static final String WORKSPACE_EXECUTE_COMMAND = "workspace/executeCommand";
 	private static final String WORKSPACE_DID_CHANGE_FOLDERS = "workspace/didChangeWorkspaceFolders";
 	private static final String WORKSPACE_DID_CHANGE_WATCHED_FILES = "workspace/didChangeWatchedFiles";
+	private static final String TEXT_DOCUMENT_CODE_ACTION = "textDocument/codeAction";
 
 	@Test
 	public void testCommandRegistration(MockLanguageServerFactory factory) throws Exception {
@@ -73,6 +93,119 @@ public class DynamicRegistrationTest extends AbstractTestWithProject {
 		}
 		assertFalse(LanguageServiceAccessor.hasActiveLanguageServers(handlesCommand("test.command")));
 		assertFalse(LanguageServiceAccessor.hasActiveLanguageServers(handlesCommand("test.command.2")));
+	}
+
+	@Test
+	public void testDynamicCodeActionRegistration(MockLanguageServerFactory factory) throws Exception {
+		final var testFile = TestUtils.createFile(project, "shouldUseExtension.lspt", "");
+		final var resolveCount = new AtomicInteger(0);
+
+		final var staticCapabilities = MockLanguageServer.defaultServerCapabilities();
+		staticCapabilities.setCodeActionProvider(Boolean.FALSE);
+		factory.withCapabilities(() -> staticCapabilities);
+		factory.withConfiguration((idx, server) -> {
+			server.getTextDocumentService().setCodeActionResolver(action -> {
+				resolveCount.incrementAndGet();
+				return action;
+			});
+			final var tEdit = new TextEdit(new Range(new Position(0, 0), new Position(0, 5)), "fixed");
+			final var wEdit = new WorkspaceEdit(Collections.singletonMap(testFile.getLocationURI().toString(), List.of(tEdit)));
+			final var codeAction = new CodeAction("fixme");
+			codeAction.setCommand(new Command("editCommand", "mockEditCommand", List.of(wEdit)));
+			server.setCodeActions(List.of(Either.forRight(codeAction)));
+			server.setDiagnostics(List.of(
+					new Diagnostic(new Range(new Position(0, 0), new Position(0, 5)), "error", DiagnosticSeverity.Error, null)));
+		});
+
+		final var document = LSPEclipseUtils.getDocument(testFile);
+		assertNotNull(document);
+		LanguageServers.forDocument(document).anyMatching();
+		waitForCondition(5_000, () -> !factory.getServers().isEmpty());
+		assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(c -> true));
+		assertFalse(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActions()));
+
+		// A real server sends CodeActionRegistrationOptions (an object), never a bare boolean
+		final var options = new CodeActionRegistrationOptions();
+		options.setCodeActionKinds(List.of(CodeActionKind.QuickFix, CodeActionKind.Refactor));
+		options.setResolveProvider(Boolean.FALSE);
+		final UUID firstRegistration = registerCodeActionProvider(factory.getServer(), options);
+
+		assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActions(o -> //
+				o.getCodeActionKinds().containsAll(List.of(CodeActionKind.QuickFix, CodeActionKind.Refactor))
+				&& Boolean.FALSE.equals(o.getResolveProvider()))));
+
+		final var editor = (AbstractTextEditor) TestUtils.openEditor(testFile);
+		IMarker m = CodeActionTests.assertDiagnostics(testFile, "error", "fixme");
+		CodeActionTests.assertResolution(editor, m, "fixed");
+		// This registration says the server does not support codeAction/resolve
+		assertEquals(0, resolveCount.get());
+
+		TestUtils.closeEditor(editor, false);
+		unregister(firstRegistration, TEXT_DOCUMENT_CODE_ACTION, factory.getServer());
+		// back to the static state (no code actions)
+		assertFalse(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActions()));
+
+		options.setResolveProvider(Boolean.TRUE);
+		registerCodeActionProvider(factory.getServer(), options);
+		assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActions()));
+
+		final var editor2 = (AbstractTextEditor) TestUtils.openEditor(testFile);
+		IMarker m2 = CodeActionTests.assertDiagnostics(testFile, "error", "fixme");
+		CodeActionTests.assertResolution(editor2, m2, "fixed");
+		// Now codeAction/resolve is supported and must have been used
+		assertEquals(1, resolveCount.get());
+	}
+
+	@Test
+	public void testCodeActionRegistrationWithoutOptions(MockLanguageServerFactory factory) throws Exception {
+		final var staticCapabilities = MockLanguageServer.defaultServerCapabilities();
+		staticCapabilities.setCodeActionProvider(Boolean.FALSE);
+		factory.withCapabilities(() -> staticCapabilities);
+		startServer(factory);
+		assertFalse(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActions()));
+
+		// registerOptions is optional: a registration without it simply enables the capability
+		final UUID registration = registerCodeActionProvider(factory.getServer(), null);
+		assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActions()));
+
+		unregister(registration, TEXT_DOCUMENT_CODE_ACTION, factory.getServer());
+		assertFalse(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActions()));
+	}
+
+	@Test
+	public void testOverlappingCodeActionRegistrations(MockLanguageServerFactory factory) throws Exception {
+		final var staticCapabilities = MockLanguageServer.defaultServerCapabilities();
+		final var staticOptions = new CodeActionOptions(List.of(CodeActionKind.Source));
+		staticCapabilities.setCodeActionProvider(staticOptions);
+		factory.withCapabilities(() -> staticCapabilities);
+		startServer(factory);
+		assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActionKinds(List.of(CodeActionKind.Source))));
+
+		final var quickFix = new CodeActionRegistrationOptions();
+		quickFix.setCodeActionKinds(List.of(CodeActionKind.QuickFix));
+		final var refactor = new CodeActionRegistrationOptions();
+		refactor.setCodeActionKinds(List.of(CodeActionKind.Refactor));
+
+		// Document selectors are not supported: the most recent registration wins as a whole
+		final UUID first = registerCodeActionProvider(factory.getServer(), quickFix);
+		assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActionKinds(List.of(CodeActionKind.QuickFix))));
+		final UUID second = registerCodeActionProvider(factory.getServer(), refactor);
+		assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActionKinds(List.of(CodeActionKind.Refactor))));
+
+		// Unregistering out of order must not disturb the remaining registration...
+		unregister(first, TEXT_DOCUMENT_CODE_ACTION, factory.getServer());
+		assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActionKinds(List.of(CodeActionKind.Refactor))));
+		// ...and removing the last one restores the static capabilities
+		unregister(second, TEXT_DOCUMENT_CODE_ACTION, factory.getServer());
+		assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActionKinds(List.of(CodeActionKind.Source))));
+
+		// Same again, unregistering in registration order: the older registration takes over
+		final UUID third = registerCodeActionProvider(factory.getServer(), quickFix);
+		final UUID fourth = registerCodeActionProvider(factory.getServer(), refactor);
+		unregister(fourth, TEXT_DOCUMENT_CODE_ACTION, factory.getServer());
+		assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActionKinds(List.of(CodeActionKind.QuickFix))));
+		unregister(third, TEXT_DOCUMENT_CODE_ACTION, factory.getServer());
+		assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActionKinds(List.of(CodeActionKind.Source))));
 	}
 
 	@Test
@@ -175,6 +308,45 @@ public class DynamicRegistrationTest extends AbstractTestWithProject {
 		registration.setRegisterOptions(new ExecuteCommandOptions(List.of(command)));
 		client.registerCapability(new RegistrationParams(List.of(registration))).get(1, TimeUnit.SECONDS);
 		return id;
+	}
+
+	private void startServer(MockLanguageServerFactory factory) throws Exception {
+		final var testFile = TestUtils.createFile(project, "shouldUseExtension.lspt", "");
+		final var document = LSPEclipseUtils.getDocument(testFile);
+		assertNotNull(document);
+		LanguageServers.forDocument(document).anyMatching();
+		waitForCondition(5_000, () -> !factory.getServers().isEmpty());
+		assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(c -> true));
+	}
+
+	private UUID registerCodeActionProvider(MockLanguageServer server, @Nullable CodeActionRegistrationOptions options)
+			throws Exception {
+		UUID id = UUID.randomUUID();
+		LanguageClient client = server.getRemoteProxy();
+		final var registration = new Registration();
+		registration.setId(id.toString());
+		registration.setMethod(TEXT_DOCUMENT_CODE_ACTION);
+		registration.setRegisterOptions(options);
+		client.registerCapability(new RegistrationParams(List.of(registration))).get(1, TimeUnit.SECONDS);
+		return id;
+	}
+
+	private Predicate<ServerCapabilities> handlesCodeActions() {
+		return cap -> {
+			final var provider = cap.getCodeActionProvider();
+			return provider != null && (provider.isRight() || Boolean.TRUE.equals(provider.getLeft()));
+		};
+	}
+
+	private Predicate<ServerCapabilities> handlesCodeActions(Predicate<CodeActionOptions> options) {
+		return cap -> {
+			final var provider = cap.getCodeActionProvider();
+			return provider != null && provider.isRight() && options.test(provider.getRight());
+		};
+	}
+
+	private Predicate<ServerCapabilities> handlesCodeActionKinds(List<String> kinds) {
+		return handlesCodeActions(o -> kinds.equals(o.getCodeActionKinds()));
 	}
 
 	private Predicate<ServerCapabilities> handlesCommand(String command) {

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/commands/DynamicRegistrationTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/commands/DynamicRegistrationTest.java
@@ -45,6 +45,7 @@ import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
+import org.eclipse.lsp4j.DocumentFilter;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
 import org.eclipse.lsp4j.FileChangeType;
 import org.eclipse.lsp4j.Position;
@@ -186,7 +187,7 @@ public class DynamicRegistrationTest extends AbstractTestWithProject {
 		final var refactor = new CodeActionRegistrationOptions();
 		refactor.setCodeActionKinds(List.of(CodeActionKind.Refactor));
 
-		// Document selectors are not supported: the most recent registration wins as a whole
+		// Without document selectors both registrations apply everywhere: the most recent wins as a whole
 		final UUID first = registerCodeActionProvider(factory.getServer(), quickFix);
 		assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActionKinds(List.of(CodeActionKind.QuickFix))));
 		final UUID second = registerCodeActionProvider(factory.getServer(), refactor);
@@ -206,6 +207,47 @@ public class DynamicRegistrationTest extends AbstractTestWithProject {
 		assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActionKinds(List.of(CodeActionKind.QuickFix))));
 		unregister(third, TEXT_DOCUMENT_CODE_ACTION, factory.getServer());
 		assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActionKinds(List.of(CodeActionKind.Source))));
+	}
+
+	@Test
+	public void testDocumentSelectorScopesRegistrationPerDocument(MockLanguageServerFactory factory) throws Exception {
+		final var staticCapabilities = MockLanguageServer.defaultServerCapabilities();
+		staticCapabilities.setCodeActionProvider(Boolean.FALSE);
+		factory.withCapabilities(() -> staticCapabilities);
+
+		final IFile matchingFile = TestUtils.createFile(project, "matching.lspt", "");
+		final IFile otherFile = TestUtils.createFile(project, "other.lspt", "");
+		final IDocument matchingDocument = LSPEclipseUtils.getDocument(matchingFile);
+		final IDocument otherDocument = LSPEclipseUtils.getDocument(otherFile);
+		assertNotNull(matchingDocument);
+		assertNotNull(otherDocument);
+		LanguageServers.forDocument(matchingDocument).anyMatching();
+		waitForCondition(5_000, () -> !factory.getServers().isEmpty());
+		LanguageServers.forDocument(otherDocument).anyMatching();
+		assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(c -> true));
+
+		// register codeAction support scoped by a glob pattern to matching.lspt only
+		final var filter = new DocumentFilter();
+		filter.setPattern("**/matching.lspt");
+		final var options = new CodeActionRegistrationOptions();
+		options.setCodeActionKinds(List.of(CodeActionKind.QuickFix));
+		options.setDocumentSelector(List.of(filter));
+		final UUID registration = registerCodeActionProvider(factory.getServer(), options);
+		try {
+			// document-scoped queries see the capability only for the matching document
+			assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(matchingDocument, handlesCodeActions()));
+			assertFalse(LanguageServiceAccessor.hasActiveLanguageServers(otherDocument, handlesCodeActions()));
+			// document-independent queries use the union view, in which every registration applies
+			assertTrue(LanguageServiceAccessor.hasActiveLanguageServers(handlesCodeActions()));
+			// the LanguageServers executor selects/skips the server per document accordingly
+			assertTrue(LanguageServers.forDocument(matchingDocument)
+					.withCapability(ServerCapabilities::getCodeActionProvider).anyMatching());
+			assertFalse(LanguageServers.forDocument(otherDocument)
+					.withCapability(ServerCapabilities::getCodeActionProvider).anyMatching());
+		} finally {
+			unregister(registration, TEXT_DOCUMENT_CODE_ACTION, factory.getServer());
+		}
+		assertFalse(LanguageServiceAccessor.hasActiveLanguageServers(matchingDocument, handlesCodeActions()));
 	}
 
 	@Test

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/internal/DocumentSelectorMatcherTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/internal/DocumentSelectorMatcherTest.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Cocotec Ltd and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Ahmed Hussain (Cocotec Ltd) - initial implementation
+ *
+ *******************************************************************************/
+package org.eclipse.lsp4e.test.internal;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.lsp4e.internal.DocumentSelectorMatcher;
+import org.eclipse.lsp4e.internal.DocumentSelectorMatcher.LanguageIdResolver;
+import org.eclipse.lsp4j.DocumentFilter;
+import org.eclipse.lsp4j.RelativePattern;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.jupiter.api.Test;
+
+class DocumentSelectorMatcherTest {
+
+	private static final URI RUST_FILE = URI.create("file:///proj/src/foo.rs");
+	private static final URI MANIFEST_FILE = URI.create("file:///proj/Cargo.toml");
+	private static final URI UNTITLED_FILE = URI.create("untitled:Untitled-1");
+
+	private final LanguageIdResolver languageIds = Map.of( //
+			RUST_FILE, "rs", //
+			MANIFEST_FILE, "toml")::get;
+
+	private static DocumentSelectorMatcher compile(DocumentFilter... filters) {
+		final DocumentSelectorMatcher matcher = DocumentSelectorMatcher.compile(List.of(filters));
+		assertNotNull(matcher);
+		return matcher;
+	}
+
+	private static DocumentFilter filter(@Nullable String language, @Nullable String scheme,
+			@Nullable String pattern) {
+		final var filter = new DocumentFilter();
+		filter.setLanguage(language);
+		filter.setScheme(scheme);
+		if (pattern != null) {
+			filter.setPattern(pattern);
+		}
+		return filter;
+	}
+
+	@Test
+	void nullSelectorCompilesToNull() {
+		assertNull(DocumentSelectorMatcher.compile(null));
+	}
+
+	@Test
+	void emptySelectorMatchesNothing() {
+		final DocumentSelectorMatcher matcher = compile();
+		assertFalse(matcher.matches(RUST_FILE, languageIds));
+	}
+
+	@Test
+	void filterWithNoUsablePropertyIsIgnored() {
+		// the spec requires at least one property to be set
+		final DocumentSelectorMatcher matcher = compile(filter(null, null, null), filter("", "", null));
+		assertFalse(matcher.matches(RUST_FILE, languageIds));
+	}
+
+	@Test
+	void languageMatching() {
+		final DocumentSelectorMatcher matcher = compile(filter("rs", null, null));
+		assertTrue(matcher.matches(RUST_FILE, languageIds));
+		assertFalse(matcher.matches(MANIFEST_FILE, languageIds));
+		// unresolvable language id: no match
+		assertFalse(matcher.matches(UNTITLED_FILE, languageIds));
+	}
+
+	@Test
+	void schemeMatchingIsCaseInsensitive() {
+		final DocumentSelectorMatcher matcher = compile(filter(null, "FILE", null));
+		assertTrue(matcher.matches(RUST_FILE, languageIds));
+		assertFalse(matcher.matches(UNTITLED_FILE, languageIds));
+	}
+
+	@Test
+	void patternMatchesAbsolutePath() {
+		assertTrue(compile(filter(null, null, "**/*.rs")).matches(RUST_FILE, languageIds));
+		assertTrue(compile(filter(null, null, "**/Cargo.toml")).matches(MANIFEST_FILE, languageIds));
+		assertFalse(compile(filter(null, null, "**/*.rs")).matches(MANIFEST_FILE, languageIds));
+	}
+
+	@Test
+	void patternNeverMatchesNonFileUris() {
+		final DocumentSelectorMatcher matcher = compile(filter(null, null, "**/*"));
+		assertFalse(matcher.matches(UNTITLED_FILE, languageIds));
+	}
+
+	@Test
+	void relativePatternMatchesRelativeToItsBase() {
+		final var relativePattern = new RelativePattern();
+		relativePattern.setBaseUri(Either.forRight("file:///proj/src"));
+		relativePattern.setPattern("*.rs");
+		final var filter = new DocumentFilter();
+		filter.setPattern(relativePattern);
+		final DocumentSelectorMatcher matcher = compile(filter);
+
+		assertTrue(matcher.matches(RUST_FILE, languageIds));
+		// same file name outside the base: no match
+		assertFalse(matcher.matches(URI.create("file:///elsewhere/foo.rs"), languageIds));
+	}
+
+	@Test
+	void propertiesOfOneFilterAreConjunctive() {
+		// language matches but scheme does not
+		assertFalse(compile(filter("rs", "untitled", null)).matches(RUST_FILE, languageIds));
+		// language matches but pattern does not
+		assertFalse(compile(filter("rs", null, "**/*.toml")).matches(RUST_FILE, languageIds));
+		// all set properties match
+		assertTrue(compile(filter("rs", "file", "**/*.rs")).matches(RUST_FILE, languageIds));
+	}
+
+	@Test
+	void filtersAreDisjunctive() {
+		final DocumentSelectorMatcher matcher = compile(filter("rs", null, null),
+				filter(null, null, "**/Cargo.toml"));
+		assertTrue(matcher.matches(RUST_FILE, languageIds));
+		assertTrue(matcher.matches(MANIFEST_FILE, languageIds));
+		assertFalse(matcher.matches(URI.create("file:///proj/readme.md"), languageIds));
+	}
+}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/internal/DynamicRegistrationManagerTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/internal/DynamicRegistrationManagerTest.java
@@ -15,13 +15,17 @@ package org.eclipse.lsp4e.test.internal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.lsp4e.internal.DynamicRegistrationManager;
@@ -31,9 +35,11 @@ import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.CodeActionOptions;
 import org.eclipse.lsp4j.CodeActionRegistrationOptions;
 import org.eclipse.lsp4j.DidChangeWatchedFilesRegistrationOptions;
+import org.eclipse.lsp4j.DocumentFilter;
 import org.eclipse.lsp4j.FileSystemWatcher;
 import org.eclipse.lsp4j.Registration;
 import org.eclipse.lsp4j.RegistrationParams;
+import org.eclipse.lsp4j.RelativePattern;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.Unregistration;
 import org.eclipse.lsp4j.UnregistrationParams;
@@ -50,14 +56,18 @@ class DynamicRegistrationManagerTest {
 	private static final String CODE_ACTION = "textDocument/codeAction";
 	private static final String WATCHED_FILES = "workspace/didChangeWatchedFiles";
 
+	private static final URI RUST_FILE = URI.create("file:///proj/foo.rs");
+	private static final URI MANIFEST_FILE = URI.create("file:///proj/Cargo.toml");
+
 	private record CapabilitiesChange(@Nullable ServerCapabilities oldCapabilities,
 			ServerCapabilities newCapabilities) {
 	}
 
 	private final List<CapabilitiesChange> changes = new ArrayList<>();
+	private final Map<URI, String> languageIds = new HashMap<>(Map.of(RUST_FILE, "rs", MANIFEST_FILE, "toml"));
 	private final FileSystemWatcherManager watcherManager = new FileSystemWatcherManager((Path) null);
 	private final DynamicRegistrationManager manager = new DynamicRegistrationManager(watcherManager,
-			(oldCaps, newCaps) -> changes.add(new CapabilitiesChange(oldCaps, newCaps)));
+			languageIds::get, (oldCaps, newCaps) -> changes.add(new CapabilitiesChange(oldCaps, newCaps)));
 
 	private static ServerCapabilities staticCapabilities() {
 		final var caps = new ServerCapabilities();
@@ -78,19 +88,50 @@ class DynamicRegistrationManagerTest {
 		manager.unregisterCapability(new UnregistrationParams(List.of(new Unregistration(id, method))));
 	}
 
-	private static CodeActionRegistrationOptions codeActionOptions(String kind) {
+	private static CodeActionRegistrationOptions codeActionOptions(String kind, DocumentFilter... selector) {
 		final var options = new CodeActionRegistrationOptions();
 		options.setCodeActionKinds(List.of(kind));
+		if (selector.length > 0) {
+			options.setDocumentSelector(List.of(selector));
+		}
 		return options;
 	}
 
+	private static DocumentFilter languageFilter(String language) {
+		final var filter = new DocumentFilter();
+		filter.setLanguage(language);
+		return filter;
+	}
+
+	private static DocumentFilter patternFilter(String pattern) {
+		final var filter = new DocumentFilter();
+		filter.setPattern(pattern);
+		return filter;
+	}
+
+	private static DocumentFilter schemeFilter(String scheme) {
+		final var filter = new DocumentFilter();
+		filter.setScheme(scheme);
+		return filter;
+	}
+
 	private List<String> effectiveCodeActionKinds() {
-		final ServerCapabilities caps = manager.getCapabilities();
+		return effectiveCodeActionKinds(null);
+	}
+
+	private List<String> effectiveCodeActionKinds(@Nullable URI uri) {
+		final ServerCapabilities caps = manager.getCapabilities(uri);
 		assertNotNull(caps);
 		final Either<Boolean, CodeActionOptions> provider = caps.getCodeActionProvider();
 		assertNotNull(provider);
 		assertTrue(provider.isRight(), "expected CodeActionOptions but was: " + provider);
 		return provider.getRight().getCodeActionKinds();
+	}
+
+	private void assertCodeActionsUnsupported(@Nullable URI uri) {
+		final ServerCapabilities caps = manager.getCapabilities(uri);
+		assertNotNull(caps);
+		assertEquals(Boolean.FALSE, caps.getCodeActionProvider().getLeft());
 	}
 
 	@Test
@@ -201,5 +242,124 @@ class DynamicRegistrationManagerTest {
 		assertNull(manager.getCapabilities());
 		assertFalse(watcherManager.hasFilePatterns());
 		assertTrue(changes.isEmpty(), "clear() must not notify the listener");
+	}
+
+	@Test
+	void languageSelectorScopesRegistrationPerDocument() {
+		manager.setStaticCapabilities(staticCapabilities());
+		register("r1", CODE_ACTION, codeActionOptions(CodeActionKind.QuickFix, languageFilter("rs")));
+
+		assertEquals(List.of(CodeActionKind.QuickFix), effectiveCodeActionKinds(RUST_FILE));
+		assertCodeActionsUnsupported(MANIFEST_FILE);
+		// the union view assumes every registration applies
+		assertEquals(List.of(CodeActionKind.QuickFix), effectiveCodeActionKinds(null));
+	}
+
+	@Test
+	void patternSelectorMatchesAbsolutePath() {
+		manager.setStaticCapabilities(staticCapabilities());
+		register("r1", CODE_ACTION, codeActionOptions(CodeActionKind.QuickFix, patternFilter("**/Cargo.toml")));
+
+		assertEquals(List.of(CodeActionKind.QuickFix), effectiveCodeActionKinds(MANIFEST_FILE));
+		assertCodeActionsUnsupported(RUST_FILE);
+	}
+
+	@Test
+	void relativePatternSelectorMatchesRelativeToItsBaseUri() {
+		manager.setStaticCapabilities(staticCapabilities());
+		final var relativePattern = new RelativePattern();
+		relativePattern.setBaseUri(Either.forRight("file:///proj")); //$NON-NLS-1$
+		relativePattern.setPattern("*.rs"); //$NON-NLS-1$
+		final var filter = new DocumentFilter();
+		filter.setPattern(relativePattern);
+		register("r1", CODE_ACTION, codeActionOptions(CodeActionKind.QuickFix, filter));
+
+		assertEquals(List.of(CodeActionKind.QuickFix), effectiveCodeActionKinds(RUST_FILE));
+		assertCodeActionsUnsupported(URI.create("file:///other/foo.rs"));
+	}
+
+	@Test
+	void schemeSelectorMatchesTheUriScheme() {
+		manager.setStaticCapabilities(staticCapabilities());
+		register("r1", CODE_ACTION, codeActionOptions(CodeActionKind.QuickFix, schemeFilter("untitled")));
+
+		assertCodeActionsUnsupported(RUST_FILE);
+		assertEquals(List.of(CodeActionKind.QuickFix),
+				effectiveCodeActionKinds(URI.create("untitled:Untitled-1.rs")));
+	}
+
+	@Test
+	void filterPropertiesAreConjunctive() {
+		manager.setStaticCapabilities(staticCapabilities());
+		final DocumentFilter filter = languageFilter("rs");
+		filter.setScheme("untitled");
+		register("r1", CODE_ACTION, codeActionOptions(CodeActionKind.QuickFix, filter));
+
+		// the language matches but the scheme does not: per spec the set properties are ANDed
+		assertCodeActionsUnsupported(RUST_FILE);
+	}
+
+	@Test
+	void selectorFiltersAreDisjunctive() {
+		manager.setStaticCapabilities(staticCapabilities());
+		register("r1", CODE_ACTION,
+				codeActionOptions(CodeActionKind.QuickFix, languageFilter("rs"), patternFilter("**/Cargo.toml")));
+
+		assertEquals(List.of(CodeActionKind.QuickFix), effectiveCodeActionKinds(RUST_FILE));
+		assertEquals(List.of(CodeActionKind.QuickFix), effectiveCodeActionKinds(MANIFEST_FILE));
+		assertCodeActionsUnsupported(URI.create("file:///proj/readme.md"));
+	}
+
+	@Test
+	void absentSelectorMatchesEveryDocument() {
+		manager.setStaticCapabilities(staticCapabilities());
+		register("r1", CODE_ACTION, codeActionOptions(CodeActionKind.QuickFix));
+
+		assertEquals(List.of(CodeActionKind.QuickFix), effectiveCodeActionKinds(RUST_FILE));
+		assertEquals(List.of(CodeActionKind.QuickFix), effectiveCodeActionKinds(MANIFEST_FILE));
+		// all registrations apply: identical to the union view
+		assertSame(manager.getCapabilities(), manager.getCapabilities(RUST_FILE));
+	}
+
+	@Test
+	void emptySelectorMatchesNoDocument() {
+		manager.setStaticCapabilities(staticCapabilities());
+		final var options = codeActionOptions(CodeActionKind.QuickFix);
+		options.setDocumentSelector(List.of());
+		register("r1", CODE_ACTION, options);
+
+		assertCodeActionsUnsupported(RUST_FILE);
+		assertCodeActionsUnsupported(MANIFEST_FILE);
+	}
+
+	@Test
+	void effectiveCapabilitiesAreCachedPerMatchingRegistrationSet() {
+		manager.setStaticCapabilities(staticCapabilities());
+		register("r1", CODE_ACTION, codeActionOptions(CodeActionKind.QuickFix, languageFilter("rs")));
+
+		languageIds.put(URI.create("file:///proj/bar.rs"), "rs");
+		final ServerCapabilities forFoo = manager.getCapabilities(RUST_FILE);
+		final ServerCapabilities forBar = manager.getCapabilities(URI.create("file:///proj/bar.rs"));
+		final ServerCapabilities forManifest = manager.getCapabilities(MANIFEST_FILE);
+		// same set of matching registrations: the same cached instance, not a recomputation
+		assertSame(forFoo, forBar);
+		assertSame(forFoo, manager.getCapabilities(RUST_FILE));
+		assertNotSame(forFoo, forManifest);
+	}
+
+	@Test
+	void overlappingSelectorsResolveToTheMostRecentRegistration() {
+		manager.setStaticCapabilities(staticCapabilities());
+		register("r1", CODE_ACTION, codeActionOptions(CodeActionKind.QuickFix, languageFilter("rs")));
+		register("r2", CODE_ACTION, codeActionOptions(CodeActionKind.Refactor, patternFilter("**/*.rs")));
+
+		// both registrations match: the most recently registered one wins
+		assertEquals(List.of(CodeActionKind.Refactor), effectiveCodeActionKinds(RUST_FILE));
+
+		// the per-set cache is invalidated by unregistration
+		unregister("r2", CODE_ACTION);
+		assertEquals(List.of(CodeActionKind.QuickFix), effectiveCodeActionKinds(RUST_FILE));
+		unregister("r1", CODE_ACTION);
+		assertCodeActionsUnsupported(RUST_FILE);
 	}
 }

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/internal/DynamicRegistrationManagerTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/internal/DynamicRegistrationManagerTest.java
@@ -1,0 +1,205 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Cocotec Ltd and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Ahmed Hussain (Cocotec Ltd) - initial implementation
+ *
+ *******************************************************************************/
+package org.eclipse.lsp4e.test.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.lsp4e.internal.DynamicRegistrationManager;
+import org.eclipse.lsp4e.internal.JsonUtil;
+import org.eclipse.lsp4e.internal.files.FileSystemWatcherManager;
+import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.CodeActionOptions;
+import org.eclipse.lsp4j.CodeActionRegistrationOptions;
+import org.eclipse.lsp4j.DidChangeWatchedFilesRegistrationOptions;
+import org.eclipse.lsp4j.FileSystemWatcher;
+import org.eclipse.lsp4j.Registration;
+import org.eclipse.lsp4j.RegistrationParams;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.Unregistration;
+import org.eclipse.lsp4j.UnregistrationParams;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link DynamicRegistrationManager}, exercising it in isolation from
+ * {@link org.eclipse.lsp4e.LanguageServerWrapper} (the end-to-end behaviour is covered by
+ * {@code DynamicRegistrationTest}).
+ */
+class DynamicRegistrationManagerTest {
+
+	private static final String CODE_ACTION = "textDocument/codeAction";
+	private static final String WATCHED_FILES = "workspace/didChangeWatchedFiles";
+
+	private record CapabilitiesChange(@Nullable ServerCapabilities oldCapabilities,
+			ServerCapabilities newCapabilities) {
+	}
+
+	private final List<CapabilitiesChange> changes = new ArrayList<>();
+	private final FileSystemWatcherManager watcherManager = new FileSystemWatcherManager((Path) null);
+	private final DynamicRegistrationManager manager = new DynamicRegistrationManager(watcherManager,
+			(oldCaps, newCaps) -> changes.add(new CapabilitiesChange(oldCaps, newCaps)));
+
+	private static ServerCapabilities staticCapabilities() {
+		final var caps = new ServerCapabilities();
+		caps.setCodeActionProvider(Boolean.FALSE);
+		return caps;
+	}
+
+	/** Registers via a raw JSON payload, as arriving over the wire. */
+	private void register(String id, String method, @Nullable Object options) {
+		final var registration = new Registration(id, method);
+		if (options != null) {
+			registration.setRegisterOptions(JsonUtil.LSP4J_GSON.toJsonTree(options));
+		}
+		manager.registerCapability(new RegistrationParams(List.of(registration)));
+	}
+
+	private void unregister(String id, String method) {
+		manager.unregisterCapability(new UnregistrationParams(List.of(new Unregistration(id, method))));
+	}
+
+	private static CodeActionRegistrationOptions codeActionOptions(String kind) {
+		final var options = new CodeActionRegistrationOptions();
+		options.setCodeActionKinds(List.of(kind));
+		return options;
+	}
+
+	private List<String> effectiveCodeActionKinds() {
+		final ServerCapabilities caps = manager.getCapabilities();
+		assertNotNull(caps);
+		final Either<Boolean, CodeActionOptions> provider = caps.getCodeActionProvider();
+		assertNotNull(provider);
+		assertTrue(provider.isRight(), "expected CodeActionOptions but was: " + provider);
+		return provider.getRight().getCodeActionKinds();
+	}
+
+	@Test
+	void nullBeforeInitialization() {
+		assertNull(manager.getCapabilities());
+	}
+
+	@Test
+	void staticCapabilitiesAreEffectiveUntilFirstRegistration() {
+		final ServerCapabilities staticCaps = staticCapabilities();
+		manager.setStaticCapabilities(staticCaps);
+		assertSame(staticCaps, manager.getCapabilities());
+		assertTrue(changes.isEmpty(), "setStaticCapabilities must not notify the listener");
+	}
+
+	@Test
+	void registerDecodesJsonPayloadAndNotifiesListener() {
+		manager.setStaticCapabilities(staticCapabilities());
+
+		final var options = codeActionOptions(CodeActionKind.QuickFix);
+		options.setResolveProvider(Boolean.TRUE);
+		register("r1", CODE_ACTION, options);
+
+		assertEquals(List.of(CodeActionKind.QuickFix), effectiveCodeActionKinds());
+		final ServerCapabilities caps = manager.getCapabilities();
+		assertNotNull(caps);
+		assertEquals(Boolean.TRUE, caps.getCodeActionProvider().getRight().getResolveProvider());
+
+		assertEquals(1, changes.size());
+		final CapabilitiesChange change = changes.get(0);
+		final ServerCapabilities oldCaps = change.oldCapabilities();
+		assertNotNull(oldCaps);
+		assertEquals(Boolean.FALSE, oldCaps.getCodeActionProvider().getLeft());
+		assertSame(caps, change.newCapabilities());
+	}
+
+	@Test
+	void absentRegisterOptionsFallBackToTrue() {
+		manager.setStaticCapabilities(staticCapabilities());
+
+		register("r1", CODE_ACTION, null);
+		ServerCapabilities caps = manager.getCapabilities();
+		assertNotNull(caps);
+		assertEquals(Boolean.TRUE, caps.getCodeActionProvider().getLeft());
+
+		unregister("r1", CODE_ACTION);
+		caps = manager.getCapabilities();
+		assertNotNull(caps);
+		assertEquals(Boolean.FALSE, caps.getCodeActionProvider().getLeft());
+	}
+
+	@Test
+	void lastRegistrationWins() {
+		manager.setStaticCapabilities(staticCapabilities());
+
+		register("r1", CODE_ACTION, codeActionOptions(CodeActionKind.QuickFix));
+		register("r2", CODE_ACTION, codeActionOptions(CodeActionKind.Refactor));
+		assertEquals(List.of(CodeActionKind.Refactor), effectiveCodeActionKinds());
+	}
+
+	@Test
+	void unregistrationOrderDoesNotMatter() {
+		manager.setStaticCapabilities(staticCapabilities());
+
+		// unregister the winner: falls back to the older live registration
+		register("r1", CODE_ACTION, codeActionOptions(CodeActionKind.QuickFix));
+		register("r2", CODE_ACTION, codeActionOptions(CodeActionKind.Refactor));
+		unregister("r2", CODE_ACTION);
+		assertEquals(List.of(CodeActionKind.QuickFix), effectiveCodeActionKinds());
+		unregister("r1", CODE_ACTION);
+
+		// unregister the loser first: the winner stays in effect
+		register("r3", CODE_ACTION, codeActionOptions(CodeActionKind.QuickFix));
+		register("r4", CODE_ACTION, codeActionOptions(CodeActionKind.Refactor));
+		unregister("r3", CODE_ACTION);
+		assertEquals(List.of(CodeActionKind.Refactor), effectiveCodeActionKinds());
+		unregister("r4", CODE_ACTION);
+
+		// all live registrations gone: back to the static capabilities
+		final ServerCapabilities caps = manager.getCapabilities();
+		assertNotNull(caps);
+		assertEquals(Boolean.FALSE, caps.getCodeActionProvider().getLeft());
+	}
+
+	@Test
+	void watchedFilesRegistrationsAreForwardedToTheWatcherManager() {
+		manager.setStaticCapabilities(staticCapabilities());
+		assertFalse(watcherManager.hasFilePatterns());
+
+		register("w1", WATCHED_FILES, new DidChangeWatchedFilesRegistrationOptions(
+				List.of(new FileSystemWatcher(Either.forLeft("**/*.txt")))));
+		assertTrue(watcherManager.hasFilePatterns());
+		assertEquals(1, changes.size(), "recompute must still notify the listener");
+
+		unregister("w1", WATCHED_FILES);
+		assertFalse(watcherManager.hasFilePatterns());
+		assertEquals(2, changes.size());
+	}
+
+	@Test
+	void clearResetsEverythingWithoutNotifying() {
+		manager.setStaticCapabilities(staticCapabilities());
+		register("w1", WATCHED_FILES, new DidChangeWatchedFilesRegistrationOptions(
+				List.of(new FileSystemWatcher(Either.forLeft("**/*.txt")))));
+		changes.clear();
+
+		manager.clear();
+		assertNull(manager.getCapabilities());
+		assertFalse(watcherManager.hasFilePatterns());
+		assertTrue(changes.isEmpty(), "clear() must not notify the listener");
+	}
+}

--- a/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/internal/JsonUtilTest.java
+++ b/org.eclipse.lsp4e.test/src/org/eclipse/lsp4e/test/internal/JsonUtilTest.java
@@ -12,10 +12,21 @@
 package org.eclipse.lsp4e.test.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.List;
 
 import org.eclipse.lsp4e.internal.JsonUtil;
+import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.CodeActionRegistrationOptions;
+import org.eclipse.lsp4j.Registration;
+import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.FileSystemWatcher;
 import org.eclipse.lsp4j.WatchKind;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.jupiter.api.Test;
 
 public class JsonUtilTest {
@@ -34,6 +45,49 @@ public class JsonUtilTest {
 		
 		FileSystemWatcher copy = JsonUtil.LSP4J_GSON.fromJson(json, FileSystemWatcher.class);
 		assertEquals(original, copy);
+	}
+
+	@Test
+	void testRegistrationOptionsFromJson() {
+		final var options = new CodeActionRegistrationOptions();
+		options.setCodeActionKinds(List.of(CodeActionKind.QuickFix, CodeActionKind.Refactor));
+		options.setResolveProvider(Boolean.FALSE);
+		final var registration = new Registration("abc123", "textDocument/codeAction", options);
+
+		// Round-trip through JSON as the transport would: registerOptions arrives as a raw JsonElement
+		final Registration received = JsonUtil.LSP4J_GSON.fromJson(JsonUtil.LSP4J_GSON.toJson(registration),
+				Registration.class);
+		assertEquals("abc123", received.getId());
+
+		final CodeActionRegistrationOptions decoded = JsonUtil.registrationOptions(received,
+				CodeActionRegistrationOptions.class);
+		assertEquals(List.of(CodeActionKind.QuickFix, CodeActionKind.Refactor), decoded.getCodeActionKinds());
+		assertFalse(decoded.getResolveProvider());
+	}
+
+	@Test
+	void testRegistrationOptionsPassThroughAndNull() {
+		final var options = new CodeActionRegistrationOptions();
+		// an in-process server may hand over the Java object directly
+		assertSame(options, JsonUtil.registrationOptions(new Registration("1", "textDocument/codeAction", options),
+				CodeActionRegistrationOptions.class));
+		// registerOptions is optional
+		assertNull(JsonUtil.registrationOptions(new Registration("2", "textDocument/codeAction", null),
+				CodeActionRegistrationOptions.class));
+	}
+
+	@Test
+	void testDeepCopy() {
+		final var original = new ServerCapabilities();
+		original.setCodeActionProvider(Boolean.TRUE);
+		original.setWorkspaceSymbolProvider(Either.forLeft(Boolean.FALSE));
+
+		final ServerCapabilities copy = JsonUtil.deepCopy(original, ServerCapabilities.class);
+		assertNotSame(original, copy);
+		assertEquals(original, copy);
+
+		copy.setCodeActionProvider(Boolean.FALSE);
+		assertEquals(Boolean.TRUE, original.getCodeActionProvider().getLeft());
 	}
 
 }

--- a/org.eclipse.lsp4e.tests.mock/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e.tests.mock/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Mock Language Server to test LSP4E
 Bundle-SymbolicName: org.eclipse.lsp4e.tests.mock
-Bundle-Version: 0.17.4.qualifier
+Bundle-Version: 0.17.5.qualifier
 Bundle-Vendor: Eclipse LSP4E
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.lsp4j,

--- a/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockTextDocumentService.java
+++ b/org.eclipse.lsp4e.tests.mock/src/org/eclipse/lsp4e/tests/mock/MockTextDocumentService.java
@@ -120,6 +120,7 @@ public class MockTextDocumentService implements TextDocumentService {
 	private Location[] mockReferences = new Location[0];
 	private List<Diagnostic> diagnostics;
 	private List<Either<Command, CodeAction>> mockCodeActions;
+	private Function<CodeAction, CodeAction> codeActionResolver = Function.identity();
 	private List<ColorInformation> mockDocumentColors;
 	private WorkspaceEdit mockRenameEdit;
 	private Either3<Range, PrepareRenameResult, PrepareRenameDefaultBehavior> mockPrepareRenameResult;
@@ -336,7 +337,7 @@ public class MockTextDocumentService implements TextDocumentService {
 
 	@Override
 	public CompletableFuture<CodeAction> resolveCodeAction(CodeAction unresolved) {
-		return CompletableFuture.completedFuture(unresolved);
+		return CompletableFuture.completedFuture(codeActionResolver.apply(unresolved));
 	}
 
 	public void setMockCompletionList(CompletionList completionList) {
@@ -397,6 +398,11 @@ public class MockTextDocumentService implements TextDocumentService {
 
 	public void setCodeActions(List<Either<Command, CodeAction>> codeActions) {
 		this.mockCodeActions = codeActions;
+	}
+
+	/** Installs a function invoked by {@code codeAction/resolve}; defaults to identity. */
+	public void setCodeActionResolver(Function<CodeAction, CodeAction> resolver) {
+		this.codeActionResolver = resolver;
 	}
 
 	public void setSignatureHelp(SignatureHelp signatureHelp) {

--- a/org.eclipse.lsp4e/META-INF/MANIFEST.MF
+++ b/org.eclipse.lsp4e/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Language Server Protocol client for Eclipse IDE (Incubation)
 Bundle-SymbolicName: org.eclipse.lsp4e;singleton:=true
-Bundle-Version: 0.19.15.qualifier
+Bundle-Version: 0.19.16.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime;bundle-version="3.12.0",
  org.eclipse.equinox.common;bundle-version="3.8.0",

--- a/org.eclipse.lsp4e/pom.xml
+++ b/org.eclipse.lsp4e/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<artifactId>org.eclipse.lsp4e</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>0.19.15-SNAPSHOT</version>
+	<version>0.19.16-SNAPSHOT</version>
 
 	<build>
 		<plugins>

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -192,7 +192,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 	}
 
 	private boolean serverSupportsWillSaveWaitUntil() {
-		ServerCapabilities serverCapabilities = languageServerWrapper.getServerCapabilities();
+		ServerCapabilities serverCapabilities = languageServerWrapper.getServerCapabilities(fileUri);
 		if(serverCapabilities != null ) {
 			Either<TextDocumentSyncKind, TextDocumentSyncOptions> textDocumentSync = serverCapabilities.getTextDocumentSync();
 			if(textDocumentSync.isRight()) {
@@ -298,7 +298,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 			ITextSelection textSelection) {
 		long modificationStamp = DocumentUtil.getDocumentModificationStamp(document);
 
-		return languageServerWrapper.getServerCapabilitiesAsync().thenCompose(capabilities -> {
+		return languageServerWrapper.getServerCapabilitiesAsync(fileUri).thenCompose(capabilities -> {
 			FormattingOptions formatOptions = LSPFormatter.getFormatOptions();
 			final var docId = new TextDocumentIdentifier(fileUri.toString());
 			if (capabilities != null && LSPFormatter.isDocumentRangeFormattingSupported(capabilities)
@@ -324,7 +324,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 			return;
 		}
 		this.openSaveStamp = buffer.getModificationStamp();
-		ServerCapabilities serverCapabilities = languageServerWrapper.getServerCapabilities();
+		ServerCapabilities serverCapabilities = languageServerWrapper.getServerCapabilities(fileUri);
 		if (serverCapabilities != null) {
 			Either<TextDocumentSyncKind, TextDocumentSyncOptions> textDocumentSync = serverCapabilities
 					.getTextDocumentSync();

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/DocumentContentSynchronizer.java
@@ -31,9 +31,6 @@ import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.content.IContentType;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.BadLocationException;
@@ -76,6 +73,7 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 	private final IDocument document;
 	private final URI fileUri;
 	private final TextDocumentSyncKind syncKind;
+	private final String languageId;
 
 	private int version = 0;
 	private @Nullable DidChangeTextDocumentParams changeParams;
@@ -111,31 +109,16 @@ final class DocumentContentSynchronizer implements IDocumentListener {
 		textDocument.setUri(fileUri.toASCIIString());
 		textDocument.setText(document.get());
 
-		List<IContentType> contentTypes = LSPEclipseUtils.getDocumentContentTypes(this.document);
-
-		String languageId = languageServerWrapper.getLanguageId(contentTypes.toArray(IContentType[]::new));
-
-		if (languageId == null && this.fileUri.getPath() != null) {
-			IPath path = Path.fromPortableString(this.fileUri.getPath());
-			languageId = path.getFileExtension();
-			if (languageId == null) {
-				languageId = path.lastSegment();
-			}
-		}
-		if (languageId == null && !this.fileUri.getSchemeSpecificPart().isEmpty()) {
-			String part = this.fileUri.getSchemeSpecificPart();
-			int lastSeparatorIndex = Math.max(part.lastIndexOf('.'), part.lastIndexOf('/'));
-			languageId = part.substring(lastSeparatorIndex + 1);
-		}
-		if (languageId == null) {
-			String uriString = uri.toString();
-			int lastSeparatorIndex = Math.max(uriString.lastIndexOf('.'), uriString.lastIndexOf('/'));
-			languageId = uriString.substring(lastSeparatorIndex + 1);
-		}
+		this.languageId = languageServerWrapper.computeLanguageId(fileUri, document);
 
 		textDocument.setLanguageId(languageId);
 		textDocument.setVersion(++version);
 		languageServer.getTextDocumentService().didOpen(new DidOpenTextDocumentParams(textDocument));
+	}
+
+	/** @return the LSP language id this document was announced with in {@code textDocument/didOpen} */
+	String getLanguageId() {
+		return languageId;
 	}
 
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -891,12 +891,16 @@ public class LanguageServerWrapper {
 		}
 		final IDocument theDocument = document;
 		return castNonNull(initializeFuture).thenAcceptAsync(theVoid -> {
+			// Computed outside the connectedDocuments monitor: getCapabilities(uri) takes the
+			// registration monitor, under which capability queries resolve a document's language id
+			// by reading connectedDocuments - taking the monitors in the opposite order here would
+			// risk a deadlock.
+			TextDocumentSyncKind syncKind = initializeFuture == null ? null
+					: castNonNull(registrationManager.getCapabilities(uri)).getTextDocumentSync().map(Functions.identity(), TextDocumentSyncOptions::getChange);
 			synchronized (connectedDocuments) {
 				if (this.connectedDocuments.containsKey(uri)) {
 					return;
 				}
-				TextDocumentSyncKind syncKind = initializeFuture == null ? null
-						: castNonNull(registrationManager.getCapabilities(uri)).getTextDocumentSync().map(Functions.identity(), TextDocumentSyncOptions::getChange);
 				final var listener = new DocumentContentSynchronizer(this, castNonNull(context.languageServer), theDocument, syncKind);
 				theDocument.addPrenotifiedDocumentListener(listener);
 				LanguageServerWrapper.this.connectedDocuments.put(uri, listener);
@@ -1235,10 +1239,15 @@ public class LanguageServerWrapper {
 		return languageId;
 	}
 
+	/**
+	 * Resolves content types for a not-yet-connected document by file name only. Deliberately no
+	 * content-based detection: this runs on capability-query threads (possibly the UI thread) and
+	 * under the registration monitor, where reading file contents is not acceptable. The resulting
+	 * language id is a best-effort answer for pre-connection selector matching; the authoritative,
+	 * content-based id is computed when the document is opened and overwrites the cache (see
+	 * {@link #computeLanguageId(URI, IDocument)}).
+	 */
 	private static List<IContentType> getContentTypes(URI uri) {
-		if (LSPEclipseUtils.findResourceFor(uri) instanceof IFile file) {
-			return LSPEclipseUtils.getFileContentTypes(file);
-		}
 		String fileName = LSPEclipseUtils.getFileName(uri);
 		if (fileName != null) {
 			return List.of(Platform.getContentTypeManager().findContentTypesFor(fileName));

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -28,12 +28,10 @@ import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.CancellationException;
@@ -65,7 +63,6 @@ import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.Adapters;
-import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProduct;
@@ -83,50 +80,32 @@ import org.eclipse.lsp4e.LanguageServersRegistry.LanguageServerDefinition;
 import org.eclipse.lsp4e.client.DefaultLanguageClient;
 import org.eclipse.lsp4e.internal.ArrayUtil;
 import org.eclipse.lsp4e.internal.CancellationUtil;
+import org.eclipse.lsp4e.internal.DynamicRegistrationManager;
 import org.eclipse.lsp4e.internal.FileBufferListenerAdapter;
-import org.eclipse.lsp4e.internal.JsonUtil;
 import org.eclipse.lsp4e.internal.SupportedFeatures;
 import org.eclipse.lsp4e.internal.files.FileSystemWatcherManager;
 import org.eclipse.lsp4e.server.StreamConnectionProvider;
 import org.eclipse.lsp4e.ui.Messages;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.ClientInfo;
-import org.eclipse.lsp4j.CodeActionOptions;
-import org.eclipse.lsp4j.CodeActionRegistrationOptions;
-import org.eclipse.lsp4j.CompletionOptions;
-import org.eclipse.lsp4j.CompletionRegistrationOptions;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
-import org.eclipse.lsp4j.DidChangeWatchedFilesRegistrationOptions;
 import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
-import org.eclipse.lsp4j.DocumentFormattingRegistrationOptions;
-import org.eclipse.lsp4j.DocumentOnTypeFormattingOptions;
-import org.eclipse.lsp4j.DocumentOnTypeFormattingRegistrationOptions;
-import org.eclipse.lsp4j.DocumentRangeFormattingRegistrationOptions;
-import org.eclipse.lsp4j.ExecuteCommandOptions;
-import org.eclipse.lsp4j.ExecuteCommandRegistrationOptions;
 import org.eclipse.lsp4j.FileChangeType;
 import org.eclipse.lsp4j.FileEvent;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.InitializedParams;
-import org.eclipse.lsp4j.Registration;
 import org.eclipse.lsp4j.RegistrationParams;
-import org.eclipse.lsp4j.SelectionRangeRegistrationOptions;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.ServerInfo;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.TextDocumentSyncOptions;
-import org.eclipse.lsp4j.TypeHierarchyRegistrationOptions;
 import org.eclipse.lsp4j.UnregistrationParams;
 import org.eclipse.lsp4j.WatchKind;
 import org.eclipse.lsp4j.WindowClientCapabilities;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.WorkspaceFoldersChangeEvent;
-import org.eclipse.lsp4j.WorkspaceFoldersOptions;
-import org.eclipse.lsp4j.WorkspaceServerCapabilities;
-import org.eclipse.lsp4j.WorkspaceSymbolOptions;
-import org.eclipse.lsp4j.WorkspaceSymbolRegistrationOptions;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
@@ -268,7 +247,6 @@ public class LanguageServerWrapper {
 	private @Nullable CompletableFuture<@Nullable Void> initializeFuture;
 
 	private volatile @Nullable InitializeResult initializeResult;
-	private volatile @Nullable ServerCapabilities serverCapabilities;
 	private volatile @Nullable ServerInfo serverInfo;
 
 	private final AtomicReference<@Nullable IProgressMonitor> initializeFutureMonitorRef = new AtomicReference<>();
@@ -284,53 +262,14 @@ public class LanguageServerWrapper {
 
 	private LanguageServerContext context = new LanguageServerContext();
 
-	/**
-	 * Map containing unregistration handlers for dynamic capability registrations.
-	 */
-	/** The capabilities from the {@code initialize} result; never modified after initialization. */
-	private volatile @Nullable ServerCapabilities staticCapabilities;
-
-	/**
-	 * Live dynamic registrations by registration id, in registration order. See
-	 * {@link #registerCapability(RegistrationParams)}.
-	 */
-	private final Map<String, DynamicRegistration> dynamicRegistrations = new LinkedHashMap<>();
-
-	private record DynamicRegistration(String method, @Nullable Object options) {
-	}
-
-	private static final String METHOD_CODE_ACTION = "textDocument/codeAction"; //$NON-NLS-1$
-	private static final String METHOD_COMPLETION = "textDocument/completion"; //$NON-NLS-1$
-	private static final String METHOD_FORMATTING = "textDocument/formatting"; //$NON-NLS-1$
-	private static final String METHOD_RANGE_FORMATTING = "textDocument/rangeFormatting"; //$NON-NLS-1$
-	private static final String METHOD_ON_TYPE_FORMATTING = "textDocument/onTypeFormatting"; //$NON-NLS-1$
-	private static final String METHOD_SELECTION_RANGE = "textDocument/selectionRange"; //$NON-NLS-1$
-	private static final String METHOD_TYPE_HIERARCHY = "textDocument/typeHierarchy"; //$NON-NLS-1$
-	private static final String METHOD_WORKSPACE_SYMBOL = "workspace/symbol"; //$NON-NLS-1$
-	private static final String METHOD_EXECUTE_COMMAND = "workspace/executeCommand"; //$NON-NLS-1$
-	private static final String METHOD_DID_CHANGE_WATCHED_FILES = "workspace/didChangeWatchedFiles"; //$NON-NLS-1$
-	private static final String METHOD_DID_CHANGE_WORKSPACE_FOLDERS = "workspace/didChangeWorkspaceFolders"; //$NON-NLS-1$
-
-	/** The LSP4J type of {@code Registration.registerOptions} for each supported method. */
-	private static final Map<String, Class<?>> REGISTRATION_OPTIONS_TYPES = Map.ofEntries( //
-			Map.entry(METHOD_CODE_ACTION, CodeActionRegistrationOptions.class), //
-			Map.entry(METHOD_COMPLETION, CompletionRegistrationOptions.class), //
-			Map.entry(METHOD_FORMATTING, DocumentFormattingRegistrationOptions.class), //
-			Map.entry(METHOD_RANGE_FORMATTING, DocumentRangeFormattingRegistrationOptions.class), //
-			Map.entry(METHOD_ON_TYPE_FORMATTING, DocumentOnTypeFormattingRegistrationOptions.class), //
-			Map.entry(METHOD_SELECTION_RANGE, SelectionRangeRegistrationOptions.class), //
-			Map.entry(METHOD_TYPE_HIERARCHY, TypeHierarchyRegistrationOptions.class), //
-			Map.entry(METHOD_WORKSPACE_SYMBOL, WorkspaceSymbolRegistrationOptions.class), //
-			Map.entry(METHOD_EXECUTE_COMMAND, ExecuteCommandRegistrationOptions.class), //
-			Map.entry(METHOD_DID_CHANGE_WATCHED_FILES, DidChangeWatchedFilesRegistrationOptions.class));
-
-	/** Methods for which several concurrent registrations are legitimate (they do not carry a document selector). */
-	private static final Set<String> ADDITIVE_REGISTRATION_METHODS = Set.of(METHOD_EXECUTE_COMMAND,
-			METHOD_DID_CHANGE_WATCHED_FILES, METHOD_DID_CHANGE_WORKSPACE_FOLDERS);
 	private boolean initiallySupportsWorkspaceFolders = false;
 	private final IResourceChangeListener workspaceFolderUpdater = new WorkspaceFolderListener();
 
-	private final FileSystemWatcherManager fileSystemWatcherManager;
+	/**
+	 * Tracks the static and dynamically registered server capabilities; owns the
+	 * {@link FileSystemWatcherManager}.
+	 */
+	private final DynamicRegistrationManager registrationManager;
 	private final WatchedFilesListener watchedFilesListener = new WatchedFilesListener();
 
 	/* Backwards compatible constructor */
@@ -372,7 +311,8 @@ public class LanguageServerWrapper {
 		this.errorProcessor = Executors
 				.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat(errorsThreadNameFormat).build());
 
-		this.fileSystemWatcherManager = new FileSystemWatcherManager(initialProject);
+		this.registrationManager = new DynamicRegistrationManager(new FileSystemWatcherManager(initialProject),
+				this::capabilitiesChanged);
 		// Read preference to determine whether to enable the workspace resource fallback for this server.
 		this.resourceFallbackEnabled = isNonBufferedFileListenerEnabled();
 	}
@@ -546,10 +486,9 @@ public class LanguageServerWrapper {
 				synchronized (workingContext) {
 					markInitializationProgress(workingContext);
 					initializeResult = res;
-					staticCapabilities = res.getCapabilities();
-					serverCapabilities = res.getCapabilities();
+					registrationManager.setStaticCapabilities(res.getCapabilities());
 					serverInfo = res.getServerInfo();
-					this.initiallySupportsWorkspaceFolders = supportsWorkspaceFolders(serverCapabilities);
+					this.initiallySupportsWorkspaceFolders = supportsWorkspaceFolders(res.getCapabilities());
 				}
 			}).thenRun(() -> {
 				synchronized (workingContext) {
@@ -801,15 +740,10 @@ public class LanguageServerWrapper {
 			this.languageClient.dispose();
 		}
 
-		this.serverCapabilities = null;
-		this.staticCapabilities = null;
-		synchronized (dynamicRegistrations) {
-			this.dynamicRegistrations.clear();
-		}
+		registrationManager.clear();
 
 		ResourcesPlugin.getWorkspace().removeResourceChangeListener(workspaceFolderUpdater);
 		ResourcesPlugin.getWorkspace().removeResourceChangeListener(watchedFilesListener);
-		fileSystemWatcherManager.clear();
 
 		CompletableFuture.runAsync(workingContext::close);
 
@@ -909,7 +843,7 @@ public class LanguageServerWrapper {
 				LanguageServerPlugin.logWarning("Could not get if the workspace folder capability is supported due to timeout after 1 second"); //$NON-NLS-1$
 			}
 		}
-		return initiallySupportsWorkspaceFolders || supportsWorkspaceFolders(serverCapabilities);
+		return initiallySupportsWorkspaceFolders || supportsWorkspaceFolders(registrationManager.getCapabilities());
 	}
 
 	/**
@@ -941,7 +875,7 @@ public class LanguageServerWrapper {
 					return;
 				}
 				TextDocumentSyncKind syncKind = initializeFuture == null ? null
-						: castNonNull(serverCapabilities).getTextDocumentSync().map(Functions.identity(), TextDocumentSyncOptions::getChange);
+						: castNonNull(registrationManager.getCapabilities()).getTextDocumentSync().map(Functions.identity(), TextDocumentSyncOptions::getChange);
 				final var listener = new DocumentContentSynchronizer(this, castNonNull(context.languageServer), theDocument, syncKind);
 				theDocument.addPrenotifiedDocumentListener(listener);
 				LanguageServerWrapper.this.connectedDocuments.put(uri, listener);
@@ -1160,7 +1094,7 @@ public class LanguageServerWrapper {
 			LanguageServerPlugin.logError(e);
 		}
 
-		return this.serverCapabilities;
+		return registrationManager.getCapabilities();
 	}
 
 	/**
@@ -1170,7 +1104,7 @@ public class LanguageServerWrapper {
 	 * immediately after initialization or if it fails to start.
 	 */
 	public CompletableFuture<@Nullable ServerCapabilities> getServerCapabilitiesAsync() {
-		return getInitializedServer().thenCompose(ls -> CompletableFuture.completedFuture(this.serverCapabilities));
+		return getInitializedServer().thenCompose(ls -> CompletableFuture.completedFuture(registrationManager.getCapabilities()));
 	}
 
 	public CompletableFuture<@Nullable ServerInfo> getServerInfoAsync() {
@@ -1193,192 +1127,44 @@ public class LanguageServerWrapper {
 
 	/**
 	 * Applies the dynamic capability registrations sent by the server via
-	 * {@code client/registerCapability}.
-	 * <p>
-	 * The static capabilities from the {@code initialize} result are never modified. Instead, the
-	 * effective {@link #serverCapabilities} are recomputed from the static capabilities plus all
-	 * currently live registrations, so that unregistering never has to "undo" anything and the
-	 * result does not depend on the order of (un)registrations.
-	 * <p>
-	 * Limitation: {@code documentSelector}s are not supported; every registration is assumed to
-	 * apply to all documents handled by this server. If a server sends several registrations for
-	 * the same method (i.e. for different selectors), the most recent one wins.
+	 * {@code client/registerCapability}. See {@link DynamicRegistrationManager} for the
+	 * capability-recomputation model and its limitations.
 	 */
 	public void registerCapability(RegistrationParams params) {
-		Assert.isNotNull(this.staticCapabilities,
-				"Dynamic capability registration failed! Server not yet initialized?"); //$NON-NLS-1$
-		synchronized (dynamicRegistrations) {
-			for (final Registration reg : params.getRegistrations()) {
-				final String id = reg.getId();
-				final String method = reg.getMethod();
-				if (dynamicRegistrations.containsKey(id)) {
-					LanguageServerPlugin.logWarning("A dynamic registration with id '" + id //$NON-NLS-1$
-							+ "' already exists and will be replaced."); //$NON-NLS-1$
-				} else if (!ADDITIVE_REGISTRATION_METHODS.contains(method)
-						&& dynamicRegistrations.values().stream().anyMatch(r -> method.equals(r.method()))) {
-					LanguageServerPlugin.logWarning("Multiple dynamic registrations for '" + method //$NON-NLS-1$
-							+ "'. Document selectors are not supported; the most recent registration will be used for all documents."); //$NON-NLS-1$
-				}
-
-				Object options = null;
-				final Class<?> optionsType = REGISTRATION_OPTIONS_TYPES.get(method);
-				if (optionsType != null) {
-					try {
-						options = JsonUtil.registrationOptions(reg, optionsType);
-					} catch (final Exception ex) {
-						LanguageServerPlugin.logError("Failed to decode options of dynamic registration for '" + method + "'", ex); //$NON-NLS-1$ //$NON-NLS-2$
-					}
-				}
-
-				if (METHOD_DID_CHANGE_WATCHED_FILES.equals(method)
-						&& options instanceof DidChangeWatchedFilesRegistrationOptions watchedFilesOptions) {
-					fileSystemWatcherManager.registerFileSystemWatchers(id, watchedFilesOptions.getWatchers());
-				}
-				// Always record the registration, even without usable options, so unregistration is clean
-				dynamicRegistrations.put(id, new DynamicRegistration(method, options));
-			}
-		}
-		recomputeCapabilities();
+		registrationManager.registerCapability(params);
 	}
 
 	public void unregisterCapability(UnregistrationParams params) {
-		synchronized (dynamicRegistrations) {
-			params.getUnregisterations().forEach(unreg -> {
-				final DynamicRegistration removed = dynamicRegistrations.remove(unreg.getId());
-				if (removed != null && METHOD_DID_CHANGE_WATCHED_FILES.equals(removed.method())) {
-					fileSystemWatcherManager.unregisterFileSystemWatchers(unreg.getId());
-				}
-			});
-		}
-		recomputeCapabilities();
+		registrationManager.unregisterCapability(params);
 	}
 
 	/**
-	 * Recomputes the effective {@link #serverCapabilities} from {@link #staticCapabilities} and
-	 * the live {@link #dynamicRegistrations}, then applies any resulting side effects.
+	 * Applies the side effects of a change to the effective server capabilities: (de)activates
+	 * the watched-files listener and starts watching projects if workspace folders have become
+	 * supported.
 	 */
-	private void recomputeCapabilities() {
-		final ServerCapabilities staticCaps = this.staticCapabilities;
-		if (staticCaps == null) {
-			return;
-		}
-		final boolean supportedWorkspaceFoldersBefore = initiallySupportsWorkspaceFolders
-				|| supportsWorkspaceFolders(this.serverCapabilities);
-		final ServerCapabilities effective = JsonUtil.deepCopy(staticCaps, ServerCapabilities.class);
-		synchronized (dynamicRegistrations) {
-			// insertion order: for methods registered more than once, the most recent registration wins
-			dynamicRegistrations.values().forEach(reg -> applyRegistration(effective, reg));
-		}
-		this.serverCapabilities = effective;
-
-		if (fileSystemWatcherManager.hasFilePatterns()) {
+	private void capabilitiesChanged(final @Nullable ServerCapabilities oldCapabilities,
+			final ServerCapabilities newCapabilities) {
+		if (registrationManager.getFileSystemWatcherManager().hasFilePatterns()) {
 			enableWatchedFiles();
 		} else {
 			disableWatchedFiles();
 		}
-		if (!supportedWorkspaceFoldersBefore && supportsWorkspaceFolders(effective)) {
+		final boolean supportedWorkspaceFoldersBefore = initiallySupportsWorkspaceFolders
+				|| supportsWorkspaceFolders(oldCapabilities);
+		if (!supportedWorkspaceFoldersBefore && supportsWorkspaceFolders(newCapabilities)) {
 			watchProjects();
 		}
 	}
 
-	private static void applyRegistration(final ServerCapabilities caps, final DynamicRegistration reg) {
-		final Object options = reg.options();
-		switch (reg.method()) {
-		case METHOD_CODE_ACTION -> {
-			if (options instanceof CodeActionRegistrationOptions o) {
-				final var codeActionOptions = new CodeActionOptions(o.getCodeActionKinds());
-				codeActionOptions.setResolveProvider(o.getResolveProvider());
-				caps.setCodeActionProvider(codeActionOptions);
-			} else {
-				caps.setCodeActionProvider(Boolean.TRUE);
-			}
-		}
-		case METHOD_COMPLETION -> {
-			final var completionOptions = new CompletionOptions();
-			if (options instanceof CompletionRegistrationOptions o) {
-				completionOptions.setTriggerCharacters(o.getTriggerCharacters());
-				completionOptions.setAllCommitCharacters(o.getAllCommitCharacters());
-				completionOptions.setResolveProvider(o.getResolveProvider());
-				completionOptions.setCompletionItem(o.getCompletionItem());
-			}
-			caps.setCompletionProvider(completionOptions);
-		}
-		case METHOD_FORMATTING -> caps.setDocumentFormattingProvider(Boolean.TRUE);
-		case METHOD_RANGE_FORMATTING -> caps.setDocumentRangeFormattingProvider(Boolean.TRUE);
-		case METHOD_ON_TYPE_FORMATTING -> {
-			if (options instanceof DocumentOnTypeFormattingRegistrationOptions o && o.getFirstTriggerCharacter() != null) {
-				caps.setDocumentOnTypeFormattingProvider(
-						new DocumentOnTypeFormattingOptions(o.getFirstTriggerCharacter(), o.getMoreTriggerCharacter()));
-			} else {
-				LanguageServerPlugin.logWarning("Ignoring dynamic registration for '" + METHOD_ON_TYPE_FORMATTING //$NON-NLS-1$
-						+ "' without a firstTriggerCharacter"); //$NON-NLS-1$
-			}
-		}
-		case METHOD_SELECTION_RANGE -> {
-			if (options instanceof SelectionRangeRegistrationOptions o) {
-				caps.setSelectionRangeProvider(o);
-			} else {
-				caps.setSelectionRangeProvider(Boolean.TRUE);
-			}
-		}
-		case METHOD_TYPE_HIERARCHY -> {
-			if (options instanceof TypeHierarchyRegistrationOptions o) {
-				caps.setTypeHierarchyProvider(o);
-			} else {
-				caps.setTypeHierarchyProvider(Boolean.TRUE);
-			}
-		}
-		case METHOD_WORKSPACE_SYMBOL -> {
-			if (options instanceof WorkspaceSymbolOptions o) { // WorkspaceSymbolRegistrationOptions extends WorkspaceSymbolOptions
-				caps.setWorkspaceSymbolProvider(o);
-			} else {
-				caps.setWorkspaceSymbolProvider(Boolean.TRUE);
-			}
-		}
-		case METHOD_EXECUTE_COMMAND -> {
-			// several executeCommand registrations are legitimate and additive
-			if (options instanceof ExecuteCommandOptions o && o.getCommands() != null) {
-				ExecuteCommandOptions provider = caps.getExecuteCommandProvider();
-				if (provider == null) {
-					provider = new ExecuteCommandOptions(new ArrayList<>());
-					caps.setExecuteCommandProvider(provider);
-				}
-				final List<String> commands = new ArrayList<>(provider.getCommands());
-				for (final String command : o.getCommands()) {
-					if (!commands.contains(command)) {
-						commands.add(command);
-					}
-				}
-				provider.setCommands(commands);
-			}
-		}
-		case METHOD_DID_CHANGE_WORKSPACE_FOLDERS -> {
-			WorkspaceServerCapabilities workspace = caps.getWorkspace();
-			if (workspace == null) {
-				workspace = new WorkspaceServerCapabilities();
-				caps.setWorkspace(workspace);
-			}
-			WorkspaceFoldersOptions folders = workspace.getWorkspaceFolders();
-			if (folders == null) {
-				folders = new WorkspaceFoldersOptions();
-				workspace.setWorkspaceFolders(folders);
-			}
-			folders.setSupported(Boolean.TRUE);
-		}
-		default -> {
-			// METHOD_DID_CHANGE_WATCHED_FILES and unknown methods: no capability change
-		}
-		}
-	}
-
 	synchronized void disableWatchedFiles() {
-		if (!fileSystemWatcherManager.hasFilePatterns()) {
+		if (!registrationManager.getFileSystemWatcherManager().hasFilePatterns()) {
 			ResourcesPlugin.getWorkspace().removeResourceChangeListener(watchedFilesListener);
 		}
 	}
 
 	synchronized void enableWatchedFiles() {
-		if (fileSystemWatcherManager.hasFilePatterns()) {
+		if (registrationManager.getFileSystemWatcherManager().hasFilePatterns()) {
 			ResourcesPlugin.getWorkspace().addResourceChangeListener(watchedFilesListener, IResourceChangeEvent.POST_CHANGE);
 		}
 	}
@@ -1545,7 +1331,7 @@ public class LanguageServerWrapper {
 		@Override
 		public void resourceChanged(final IResourceChangeEvent event) {
 			// Fast-path: if no watchers are registered, skip work entirely
-			if (!fileSystemWatcherManager.hasFilePatterns())
+			if (!registrationManager.getFileSystemWatcherManager().hasFilePatterns())
 				return;
 
 			final List<WatchedFileChange> changes = collectChanges(event);
@@ -1571,7 +1357,7 @@ public class LanguageServerWrapper {
 				final var fileEvents = new ArrayList<FileEvent>();
 				for (final WatchedFileChange change : changes) {
 					final int watchKind = toWatchKind(change.changeType());
-					if (!fileSystemWatcherManager.isMatchFilePattern(change.uri(), watchKind)) {
+					if (!registrationManager.getFileSystemWatcherManager().isMatchFilePattern(change.uri(), watchKind)) {
 						continue;
 					}
 					final var fileEvent = new FileEvent();

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -27,7 +27,9 @@ import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -68,6 +70,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProduct;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
@@ -272,6 +275,24 @@ public class LanguageServerWrapper {
 	private final DynamicRegistrationManager registrationManager;
 	private final WatchedFilesListener watchedFilesListener = new WatchedFilesListener();
 
+	private static final int LANGUAGE_ID_CACHE_SIZE = 100;
+
+	/**
+	 * Caches the language id computed for not-yet-connected documents by {@link #getLanguageId(URI)}
+	 * (for connected documents the id sent in {@code didOpen} is used directly). The language id of a
+	 * URI is stable, so this cache survives dynamic (un)registrations; it is bounded because
+	 * capability queries can pass arbitrarily many URIs over a server's lifetime.
+	 */
+	private final Map<URI, String> languageIdsByUri = Collections
+			.synchronizedMap(new LinkedHashMap<>(16, 0.75f, true) {
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				protected boolean removeEldestEntry(final Map.@Nullable Entry<URI, String> eldest) {
+					return size() > LANGUAGE_ID_CACHE_SIZE;
+				}
+			});
+
 	/* Backwards compatible constructor */
 	public LanguageServerWrapper(IProject project, LanguageServerDefinition serverDefinition) {
 		this(project, serverDefinition, null);
@@ -312,7 +333,7 @@ public class LanguageServerWrapper {
 				.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat(errorsThreadNameFormat).build());
 
 		this.registrationManager = new DynamicRegistrationManager(new FileSystemWatcherManager(initialProject),
-				this::capabilitiesChanged);
+				this::getLanguageId, this::capabilitiesChanged);
 		// Read preference to determine whether to enable the workspace resource fallback for this server.
 		this.resourceFallbackEnabled = isNonBufferedFileListenerEnabled();
 	}
@@ -875,7 +896,7 @@ public class LanguageServerWrapper {
 					return;
 				}
 				TextDocumentSyncKind syncKind = initializeFuture == null ? null
-						: castNonNull(registrationManager.getCapabilities()).getTextDocumentSync().map(Functions.identity(), TextDocumentSyncOptions::getChange);
+						: castNonNull(registrationManager.getCapabilities(uri)).getTextDocumentSync().map(Functions.identity(), TextDocumentSyncOptions::getChange);
 				final var listener = new DocumentContentSynchronizer(this, castNonNull(context.languageServer), theDocument, syncKind);
 				theDocument.addPrenotifiedDocumentListener(listener);
 				LanguageServerWrapper.this.connectedDocuments.put(uri, listener);
@@ -1077,10 +1098,24 @@ public class LanguageServerWrapper {
 	 * <b>IMPORTANT:</b> If the server isn't yet initialized this method will be
 	 * blocking for up to 10 seconds!
 	 *
-	 * @return the server capabilities, or null if initialization job didn't
-	 *         complete
+	 * @return the server capabilities assuming every dynamic capability registration applies (the
+	 *         union view), or null if initialization job didn't complete
 	 */
 	public @Nullable ServerCapabilities getServerCapabilities() {
+		return getServerCapabilities(null);
+	}
+
+	/**
+	 * <b>IMPORTANT:</b> If the server isn't yet initialized this method will be
+	 * blocking for up to 10 seconds!
+	 *
+	 * @param uri the URI of the document the capabilities are queried for: dynamic capability
+	 *            registrations only contribute where their {@code documentSelector} matches it.
+	 *            {@code null} yields the union view in which every registration applies.
+	 * @return the effective server capabilities for the given document, or null if initialization
+	 *         job didn't complete
+	 */
+	public @Nullable ServerCapabilities getServerCapabilities(@Nullable URI uri) {
 		try {
 			getInitializedServer().get(10, TimeUnit.SECONDS);
 		} catch (TimeoutException e) {
@@ -1094,17 +1129,32 @@ public class LanguageServerWrapper {
 			LanguageServerPlugin.logError(e);
 		}
 
-		return registrationManager.getCapabilities();
+		return registrationManager.getCapabilities(uri);
 	}
 
 	/**
-	 * @return a {@link CompletableFuture} that provides the {@link ServerCapabilities}.
+	 * @return a {@link CompletableFuture} that provides the {@link ServerCapabilities}, assuming
+	 * every dynamic capability registration applies (the union view).
 	 * <p>
 	 * The {@link ServerCapabilities} will be {@code null} if the server shuts down
 	 * immediately after initialization or if it fails to start.
 	 */
 	public CompletableFuture<@Nullable ServerCapabilities> getServerCapabilitiesAsync() {
-		return getInitializedServer().thenCompose(ls -> CompletableFuture.completedFuture(registrationManager.getCapabilities()));
+		return getServerCapabilitiesAsync(null);
+	}
+
+	/**
+	 * @param uri the URI of the document the capabilities are queried for: dynamic capability
+	 *            registrations only contribute where their {@code documentSelector} matches it.
+	 *            {@code null} yields the union view in which every registration applies.
+	 * @return a {@link CompletableFuture} that provides the effective {@link ServerCapabilities}
+	 * for the given document.
+	 * <p>
+	 * The {@link ServerCapabilities} will be {@code null} if the server shuts down
+	 * immediately after initialization or if it fails to start.
+	 */
+	public CompletableFuture<@Nullable ServerCapabilities> getServerCapabilitiesAsync(@Nullable URI uri) {
+		return getInitializedServer().thenCompose(ls -> CompletableFuture.completedFuture(registrationManager.getCapabilities(uri)));
 	}
 
 	public CompletableFuture<@Nullable ServerInfo> getServerInfoAsync() {
@@ -1123,6 +1173,77 @@ public class LanguageServerWrapper {
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Returns the LSP language id of the document at the given URI for this server: for a connected
+	 * document the id that was sent in {@code textDocument/didOpen}, otherwise the id that would be
+	 * sent if the document were opened. Used to match the {@code documentSelector}s of dynamic
+	 * capability registrations, which must agree with what the server was told at {@code didOpen}.
+	 * <p>
+	 * Answers for unconnected documents are served read-through from {@link #languageIdsByUri}, so
+	 * repeated capability queries do not repeat the content-type lookup.
+	 */
+	String getLanguageId(URI uri) {
+		synchronized (connectedDocuments) {
+			DocumentContentSynchronizer synchronizer = connectedDocuments.get(uri);
+			if (synchronizer != null) {
+				return synchronizer.getLanguageId();
+			}
+		}
+		return castNonNull(languageIdsByUri.computeIfAbsent(uri, u -> computeLanguageIdImpl(u, null)));
+	}
+
+	/**
+	 * Computes the LSP language id to send in {@code textDocument/didOpen} for the given document:
+	 * the {@code languageId} declared in this server's content-type mappings if any, otherwise the
+	 * file extension, falling back to the last segment of the URI.
+	 * <p>
+	 * Deliberately not served from {@link #languageIdsByUri}: with the document in hand, content-type
+	 * detection is content-based and thus more authoritative than a cached name-based answer from an
+	 * earlier {@link #getLanguageId(URI)} call, so this always computes and overwrites the cache —
+	 * keeping post-disconnect queries consistent with what {@code didOpen} last sent.
+	 */
+	String computeLanguageId(URI uri, IDocument document) {
+		String languageId = computeLanguageIdImpl(uri, document);
+		languageIdsByUri.put(uri, languageId);
+		return languageId;
+	}
+
+	private String computeLanguageIdImpl(URI uri, @Nullable IDocument document) {
+		List<IContentType> contentTypes = document != null //
+				? LSPEclipseUtils.getDocumentContentTypes(document)
+				: getContentTypes(uri);
+		String languageId = getLanguageId(contentTypes.toArray(IContentType[]::new));
+		if (languageId == null && uri.getPath() != null) {
+			IPath path = Path.fromPortableString(uri.getPath());
+			languageId = path.getFileExtension();
+			if (languageId == null) {
+				languageId = path.lastSegment();
+			}
+		}
+		if (languageId == null && !uri.getSchemeSpecificPart().isEmpty()) {
+			String part = uri.getSchemeSpecificPart();
+			int lastSeparatorIndex = Math.max(part.lastIndexOf('.'), part.lastIndexOf('/'));
+			languageId = part.substring(lastSeparatorIndex + 1);
+		}
+		if (languageId == null) {
+			String uriString = uri.toString();
+			int lastSeparatorIndex = Math.max(uriString.lastIndexOf('.'), uriString.lastIndexOf('/'));
+			languageId = uriString.substring(lastSeparatorIndex + 1);
+		}
+		return languageId;
+	}
+
+	private static List<IContentType> getContentTypes(URI uri) {
+		if (LSPEclipseUtils.findResourceFor(uri) instanceof IFile file) {
+			return LSPEclipseUtils.getFileContentTypes(file);
+		}
+		String fileName = LSPEclipseUtils.getFileName(uri);
+		if (fileName != null) {
+			return List.of(Platform.getContentTypeManager().findContentTypesFor(fileName));
+		}
+		return List.of();
 	}
 
 	/**

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServerWrapper.java
@@ -28,10 +28,12 @@ import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.CancellationException;
@@ -65,7 +67,6 @@ import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProduct;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -91,15 +92,19 @@ import org.eclipse.lsp4e.ui.Messages;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.ClientInfo;
 import org.eclipse.lsp4j.CodeActionOptions;
+import org.eclipse.lsp4j.CodeActionRegistrationOptions;
 import org.eclipse.lsp4j.CompletionOptions;
+import org.eclipse.lsp4j.CompletionRegistrationOptions;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesRegistrationOptions;
 import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
-import org.eclipse.lsp4j.DocumentFormattingOptions;
+import org.eclipse.lsp4j.DocumentFormattingRegistrationOptions;
 import org.eclipse.lsp4j.DocumentOnTypeFormattingOptions;
-import org.eclipse.lsp4j.DocumentRangeFormattingOptions;
+import org.eclipse.lsp4j.DocumentOnTypeFormattingRegistrationOptions;
+import org.eclipse.lsp4j.DocumentRangeFormattingRegistrationOptions;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
+import org.eclipse.lsp4j.ExecuteCommandRegistrationOptions;
 import org.eclipse.lsp4j.FileChangeType;
 import org.eclipse.lsp4j.FileEvent;
 import org.eclipse.lsp4j.InitializeParams;
@@ -121,10 +126,10 @@ import org.eclipse.lsp4j.WorkspaceFoldersChangeEvent;
 import org.eclipse.lsp4j.WorkspaceFoldersOptions;
 import org.eclipse.lsp4j.WorkspaceServerCapabilities;
 import org.eclipse.lsp4j.WorkspaceSymbolOptions;
+import org.eclipse.lsp4j.WorkspaceSymbolRegistrationOptions;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.messages.Message;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage;
@@ -134,7 +139,6 @@ import org.eclipse.swt.widgets.Display;
 
 import com.google.common.base.Functions;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.google.gson.JsonObject;
 
 public class LanguageServerWrapper {
 
@@ -283,7 +287,46 @@ public class LanguageServerWrapper {
 	/**
 	 * Map containing unregistration handlers for dynamic capability registrations.
 	 */
-	private final Map<String, Runnable> dynamicRegistrations = new HashMap<>();
+	/** The capabilities from the {@code initialize} result; never modified after initialization. */
+	private volatile @Nullable ServerCapabilities staticCapabilities;
+
+	/**
+	 * Live dynamic registrations by registration id, in registration order. See
+	 * {@link #registerCapability(RegistrationParams)}.
+	 */
+	private final Map<String, DynamicRegistration> dynamicRegistrations = new LinkedHashMap<>();
+
+	private record DynamicRegistration(String method, @Nullable Object options) {
+	}
+
+	private static final String METHOD_CODE_ACTION = "textDocument/codeAction"; //$NON-NLS-1$
+	private static final String METHOD_COMPLETION = "textDocument/completion"; //$NON-NLS-1$
+	private static final String METHOD_FORMATTING = "textDocument/formatting"; //$NON-NLS-1$
+	private static final String METHOD_RANGE_FORMATTING = "textDocument/rangeFormatting"; //$NON-NLS-1$
+	private static final String METHOD_ON_TYPE_FORMATTING = "textDocument/onTypeFormatting"; //$NON-NLS-1$
+	private static final String METHOD_SELECTION_RANGE = "textDocument/selectionRange"; //$NON-NLS-1$
+	private static final String METHOD_TYPE_HIERARCHY = "textDocument/typeHierarchy"; //$NON-NLS-1$
+	private static final String METHOD_WORKSPACE_SYMBOL = "workspace/symbol"; //$NON-NLS-1$
+	private static final String METHOD_EXECUTE_COMMAND = "workspace/executeCommand"; //$NON-NLS-1$
+	private static final String METHOD_DID_CHANGE_WATCHED_FILES = "workspace/didChangeWatchedFiles"; //$NON-NLS-1$
+	private static final String METHOD_DID_CHANGE_WORKSPACE_FOLDERS = "workspace/didChangeWorkspaceFolders"; //$NON-NLS-1$
+
+	/** The LSP4J type of {@code Registration.registerOptions} for each supported method. */
+	private static final Map<String, Class<?>> REGISTRATION_OPTIONS_TYPES = Map.ofEntries( //
+			Map.entry(METHOD_CODE_ACTION, CodeActionRegistrationOptions.class), //
+			Map.entry(METHOD_COMPLETION, CompletionRegistrationOptions.class), //
+			Map.entry(METHOD_FORMATTING, DocumentFormattingRegistrationOptions.class), //
+			Map.entry(METHOD_RANGE_FORMATTING, DocumentRangeFormattingRegistrationOptions.class), //
+			Map.entry(METHOD_ON_TYPE_FORMATTING, DocumentOnTypeFormattingRegistrationOptions.class), //
+			Map.entry(METHOD_SELECTION_RANGE, SelectionRangeRegistrationOptions.class), //
+			Map.entry(METHOD_TYPE_HIERARCHY, TypeHierarchyRegistrationOptions.class), //
+			Map.entry(METHOD_WORKSPACE_SYMBOL, WorkspaceSymbolRegistrationOptions.class), //
+			Map.entry(METHOD_EXECUTE_COMMAND, ExecuteCommandRegistrationOptions.class), //
+			Map.entry(METHOD_DID_CHANGE_WATCHED_FILES, DidChangeWatchedFilesRegistrationOptions.class));
+
+	/** Methods for which several concurrent registrations are legitimate (they do not carry a document selector). */
+	private static final Set<String> ADDITIVE_REGISTRATION_METHODS = Set.of(METHOD_EXECUTE_COMMAND,
+			METHOD_DID_CHANGE_WATCHED_FILES, METHOD_DID_CHANGE_WORKSPACE_FOLDERS);
 	private boolean initiallySupportsWorkspaceFolders = false;
 	private final IResourceChangeListener workspaceFolderUpdater = new WorkspaceFolderListener();
 
@@ -503,6 +546,7 @@ public class LanguageServerWrapper {
 				synchronized (workingContext) {
 					markInitializationProgress(workingContext);
 					initializeResult = res;
+					staticCapabilities = res.getCapabilities();
 					serverCapabilities = res.getCapabilities();
 					serverInfo = res.getServerInfo();
 					this.initiallySupportsWorkspaceFolders = supportsWorkspaceFolders(serverCapabilities);
@@ -758,7 +802,10 @@ public class LanguageServerWrapper {
 		}
 
 		this.serverCapabilities = null;
-		this.dynamicRegistrations.clear();
+		this.staticCapabilities = null;
+		synchronized (dynamicRegistrations) {
+			this.dynamicRegistrations.clear();
+		}
 
 		ResourcesPlugin.getWorkspace().removeResourceChangeListener(workspaceFolderUpdater);
 		ResourcesPlugin.getWorkspace().removeResourceChangeListener(watchedFilesListener);
@@ -1144,143 +1191,183 @@ public class LanguageServerWrapper {
 		return null;
 	}
 
+	/**
+	 * Applies the dynamic capability registrations sent by the server via
+	 * {@code client/registerCapability}.
+	 * <p>
+	 * The static capabilities from the {@code initialize} result are never modified. Instead, the
+	 * effective {@link #serverCapabilities} are recomputed from the static capabilities plus all
+	 * currently live registrations, so that unregistering never has to "undo" anything and the
+	 * result does not depend on the order of (un)registrations.
+	 * <p>
+	 * Limitation: {@code documentSelector}s are not supported; every registration is assumed to
+	 * apply to all documents handled by this server. If a server sends several registrations for
+	 * the same method (i.e. for different selectors), the most recent one wins.
+	 */
 	public void registerCapability(RegistrationParams params) {
-		final var serverCapabilities = this.serverCapabilities;
-		Assert.isNotNull(serverCapabilities,
+		Assert.isNotNull(this.staticCapabilities,
 				"Dynamic capability registration failed! Server not yet initialized?"); //$NON-NLS-1$
-		params.getRegistrations().forEach(reg -> {
-			switch (reg.getMethod()) {
-			case "workspace/didChangeWatchedFiles": { //$NON-NLS-1$
-				try {
-					DidChangeWatchedFilesRegistrationOptions options = toDidChangeWatchedFilesRegistrationOptions(
-							reg.getRegisterOptions());
-					if (options != null && !options.getWatchers().isEmpty()) {
-						fileSystemWatcherManager.registerFileSystemWatchers(reg.getId(), options.getWatchers());
-						enableWatchedFiles();
-						addRegistration(reg, () -> {
-							fileSystemWatcherManager.unregisterFileSystemWatchers(reg.getId());
-							disableWatchedFiles();
-						});
-					} else {
-						// No usable watchers - still track registration so it can be unregistered cleanly
-						addRegistration(reg, this::disableWatchedFiles);
-					}
-				} catch (final Exception ex) {
-					LanguageServerPlugin.logError(ex);
-					addRegistration(reg, this::disableWatchedFiles);
-				}
-				break;
-			}
-			case "workspace/didChangeWorkspaceFolders":  //$NON-NLS-1$
-				if (initiallySupportsWorkspaceFolders) {
-					// Can treat this as a NOP since nothing can disable it dynamically if it was
-					// enabled on initialization.
-				} else if (supportsWorkspaceFolders(serverCapabilities)) {
-					LanguageServerPlugin.logWarning(
-							"Dynamic registration of 'workspace/didChangeWorkspaceFolders' ignored. It was already enabled before"); //$NON-NLS-1$
-				} else {
-					addRegistration(reg, () -> setWorkspaceFoldersEnablement(false));
-					setWorkspaceFoldersEnablement(true);
-				}
-				break;
-			case "workspace/executeCommand": //$NON-NLS-1$
-				try {
-					ExecuteCommandOptions executeCommandOptions = castNonNull(JsonUtil.LSP4J_GSON.fromJson((JsonObject) reg.getRegisterOptions(),
-							ExecuteCommandOptions.class));
-					List<String> newCommands = executeCommandOptions.getCommands();
-					if (!newCommands.isEmpty()) {
-						addRegistration(reg, () -> unregisterCommands(newCommands));
-						registerCommands(newCommands);
-					}
-				} catch (final Exception ex) {
-					LanguageServerPlugin.logError(ex);
-				}
-				break;
-			case "textDocument/formatting": //$NON-NLS-1$
-				Either<Boolean, DocumentFormattingOptions> documentFormattingProvider = serverCapabilities
-						.getDocumentFormattingProvider();
-				if (documentFormattingProvider == null || documentFormattingProvider.isLeft()) {
-					serverCapabilities.setDocumentFormattingProvider(Boolean.TRUE);
-				} else {
-					serverCapabilities.setDocumentFormattingProvider(documentFormattingProvider.getRight());
-				}
-				addRegistration(reg, () -> serverCapabilities.setDocumentFormattingProvider(documentFormattingProvider));
-				break;
-			case "textDocument/rangeFormatting": //$NON-NLS-1$
-				Either<Boolean, DocumentRangeFormattingOptions> documentRangeFormattingProvider = serverCapabilities
-						.getDocumentRangeFormattingProvider();
-				if (documentRangeFormattingProvider == null || documentRangeFormattingProvider.isLeft()) {
-					serverCapabilities.setDocumentRangeFormattingProvider(Boolean.TRUE);
-				} else {
-					serverCapabilities.setDocumentRangeFormattingProvider(documentRangeFormattingProvider.getRight());
-				}
-				addRegistration(reg, () -> serverCapabilities.setDocumentRangeFormattingProvider(documentRangeFormattingProvider));
-				break;
-			case "textDocument/codeAction": //$NON-NLS-1$
-				final Either<Boolean, CodeActionOptions> beforeRegistration = serverCapabilities.getCodeActionProvider();
-				serverCapabilities.setCodeActionProvider(Boolean.TRUE);
-				addRegistration(reg, () -> serverCapabilities.setCodeActionProvider(beforeRegistration));
-				break;
-			case "textDocument/completion": { //$NON-NLS-1$
-				CompletionOptions previous = serverCapabilities.getCompletionProvider();
-				try {
-					final var completionOpts = JsonUtil.LSP4J_GSON.fromJson((JsonObject) reg.getRegisterOptions(),
-							CompletionOptions.class);
-					serverCapabilities.setCompletionProvider(completionOpts);
-					addRegistration(reg, () -> serverCapabilities.setCompletionProvider(previous));
-				} catch (final Exception ex) {
-					LanguageServerPlugin.logError(ex);
-				}
-				break;
-			}
-			case "workspace/symbol": //$NON-NLS-1$
-				final Either<Boolean, WorkspaceSymbolOptions> workspaceSymbolBeforeRegistration = serverCapabilities.getWorkspaceSymbolProvider();
-				serverCapabilities.setWorkspaceSymbolProvider(Boolean.TRUE);
-				addRegistration(reg, () -> serverCapabilities.setWorkspaceSymbolProvider(workspaceSymbolBeforeRegistration));
-				break;
-			case "textDocument/selectionRange": //$NON-NLS-1$
-				Either<Boolean, SelectionRangeRegistrationOptions> selectionRangeProvider = serverCapabilities
-						.getSelectionRangeProvider();
-				if (selectionRangeProvider == null || selectionRangeProvider.isLeft()) {
-					serverCapabilities.setSelectionRangeProvider(Boolean.TRUE);
-				} else {
-					serverCapabilities.setSelectionRangeProvider(selectionRangeProvider.getRight());
-				}
-				addRegistration(reg, () -> serverCapabilities.setSelectionRangeProvider(selectionRangeProvider));
-				break;
-			case "textDocument/typeHierarchy": //$NON-NLS-1$
-				final Either<Boolean, TypeHierarchyRegistrationOptions> typeHierarchyBeforeRegistration = serverCapabilities.getTypeHierarchyProvider();
-				serverCapabilities.setTypeHierarchyProvider(Boolean.TRUE);
-				addRegistration(reg, () -> serverCapabilities.setTypeHierarchyProvider(typeHierarchyBeforeRegistration));
-				break;
-			case "textDocument/onTypeFormatting": //$NON-NLS-1$
-				final var onTypeFormattingBeforeRegistration = serverCapabilities.getDocumentOnTypeFormattingProvider();
-				serverCapabilities.setDocumentOnTypeFormattingProvider(reg.getRegisterOptions() instanceof DocumentOnTypeFormattingOptions opts ? opts : null);
-				addRegistration(reg, () -> serverCapabilities.setDocumentOnTypeFormattingProvider(onTypeFormattingBeforeRegistration));
-				break;
-		}});
-	}
-
-	private static @Nullable DidChangeWatchedFilesRegistrationOptions toDidChangeWatchedFilesRegistrationOptions(
-			@Nullable Object registerOptions) {
-		if (registerOptions == null)
-			return null;
-		if (registerOptions instanceof DidChangeWatchedFilesRegistrationOptions direct)
-			return direct;
-		if (registerOptions instanceof JsonObject jsonObject) {
-			return JsonUtil.LSP4J_GSON.fromJson(jsonObject, DidChangeWatchedFilesRegistrationOptions.class);
-		}
-		return null;
-	}
-
-	private void addRegistration(Registration reg, Runnable unregistrationHandler) {
-		String regId = reg.getId();
 		synchronized (dynamicRegistrations) {
-			if (dynamicRegistrations.containsKey(regId)) {
-				ILog.get().warn("A registration with id " + regId + " already exists. Unregistering may not fully work in this case.\n"); //$NON-NLS-1$ //$NON-NLS-2$
-			} else {
-				dynamicRegistrations.put(regId, unregistrationHandler);
+			for (final Registration reg : params.getRegistrations()) {
+				final String id = reg.getId();
+				final String method = reg.getMethod();
+				if (dynamicRegistrations.containsKey(id)) {
+					LanguageServerPlugin.logWarning("A dynamic registration with id '" + id //$NON-NLS-1$
+							+ "' already exists and will be replaced."); //$NON-NLS-1$
+				} else if (!ADDITIVE_REGISTRATION_METHODS.contains(method)
+						&& dynamicRegistrations.values().stream().anyMatch(r -> method.equals(r.method()))) {
+					LanguageServerPlugin.logWarning("Multiple dynamic registrations for '" + method //$NON-NLS-1$
+							+ "'. Document selectors are not supported; the most recent registration will be used for all documents."); //$NON-NLS-1$
+				}
+
+				Object options = null;
+				final Class<?> optionsType = REGISTRATION_OPTIONS_TYPES.get(method);
+				if (optionsType != null) {
+					try {
+						options = JsonUtil.registrationOptions(reg, optionsType);
+					} catch (final Exception ex) {
+						LanguageServerPlugin.logError("Failed to decode options of dynamic registration for '" + method + "'", ex); //$NON-NLS-1$ //$NON-NLS-2$
+					}
+				}
+
+				if (METHOD_DID_CHANGE_WATCHED_FILES.equals(method)
+						&& options instanceof DidChangeWatchedFilesRegistrationOptions watchedFilesOptions) {
+					fileSystemWatcherManager.registerFileSystemWatchers(id, watchedFilesOptions.getWatchers());
+				}
+				// Always record the registration, even without usable options, so unregistration is clean
+				dynamicRegistrations.put(id, new DynamicRegistration(method, options));
 			}
+		}
+		recomputeCapabilities();
+	}
+
+	public void unregisterCapability(UnregistrationParams params) {
+		synchronized (dynamicRegistrations) {
+			params.getUnregisterations().forEach(unreg -> {
+				final DynamicRegistration removed = dynamicRegistrations.remove(unreg.getId());
+				if (removed != null && METHOD_DID_CHANGE_WATCHED_FILES.equals(removed.method())) {
+					fileSystemWatcherManager.unregisterFileSystemWatchers(unreg.getId());
+				}
+			});
+		}
+		recomputeCapabilities();
+	}
+
+	/**
+	 * Recomputes the effective {@link #serverCapabilities} from {@link #staticCapabilities} and
+	 * the live {@link #dynamicRegistrations}, then applies any resulting side effects.
+	 */
+	private void recomputeCapabilities() {
+		final ServerCapabilities staticCaps = this.staticCapabilities;
+		if (staticCaps == null) {
+			return;
+		}
+		final boolean supportedWorkspaceFoldersBefore = initiallySupportsWorkspaceFolders
+				|| supportsWorkspaceFolders(this.serverCapabilities);
+		final ServerCapabilities effective = JsonUtil.deepCopy(staticCaps, ServerCapabilities.class);
+		synchronized (dynamicRegistrations) {
+			// insertion order: for methods registered more than once, the most recent registration wins
+			dynamicRegistrations.values().forEach(reg -> applyRegistration(effective, reg));
+		}
+		this.serverCapabilities = effective;
+
+		if (fileSystemWatcherManager.hasFilePatterns()) {
+			enableWatchedFiles();
+		} else {
+			disableWatchedFiles();
+		}
+		if (!supportedWorkspaceFoldersBefore && supportsWorkspaceFolders(effective)) {
+			watchProjects();
+		}
+	}
+
+	private static void applyRegistration(final ServerCapabilities caps, final DynamicRegistration reg) {
+		final Object options = reg.options();
+		switch (reg.method()) {
+		case METHOD_CODE_ACTION -> {
+			if (options instanceof CodeActionRegistrationOptions o) {
+				final var codeActionOptions = new CodeActionOptions(o.getCodeActionKinds());
+				codeActionOptions.setResolveProvider(o.getResolveProvider());
+				caps.setCodeActionProvider(codeActionOptions);
+			} else {
+				caps.setCodeActionProvider(Boolean.TRUE);
+			}
+		}
+		case METHOD_COMPLETION -> {
+			final var completionOptions = new CompletionOptions();
+			if (options instanceof CompletionRegistrationOptions o) {
+				completionOptions.setTriggerCharacters(o.getTriggerCharacters());
+				completionOptions.setAllCommitCharacters(o.getAllCommitCharacters());
+				completionOptions.setResolveProvider(o.getResolveProvider());
+				completionOptions.setCompletionItem(o.getCompletionItem());
+			}
+			caps.setCompletionProvider(completionOptions);
+		}
+		case METHOD_FORMATTING -> caps.setDocumentFormattingProvider(Boolean.TRUE);
+		case METHOD_RANGE_FORMATTING -> caps.setDocumentRangeFormattingProvider(Boolean.TRUE);
+		case METHOD_ON_TYPE_FORMATTING -> {
+			if (options instanceof DocumentOnTypeFormattingRegistrationOptions o && o.getFirstTriggerCharacter() != null) {
+				caps.setDocumentOnTypeFormattingProvider(
+						new DocumentOnTypeFormattingOptions(o.getFirstTriggerCharacter(), o.getMoreTriggerCharacter()));
+			} else {
+				LanguageServerPlugin.logWarning("Ignoring dynamic registration for '" + METHOD_ON_TYPE_FORMATTING //$NON-NLS-1$
+						+ "' without a firstTriggerCharacter"); //$NON-NLS-1$
+			}
+		}
+		case METHOD_SELECTION_RANGE -> {
+			if (options instanceof SelectionRangeRegistrationOptions o) {
+				caps.setSelectionRangeProvider(o);
+			} else {
+				caps.setSelectionRangeProvider(Boolean.TRUE);
+			}
+		}
+		case METHOD_TYPE_HIERARCHY -> {
+			if (options instanceof TypeHierarchyRegistrationOptions o) {
+				caps.setTypeHierarchyProvider(o);
+			} else {
+				caps.setTypeHierarchyProvider(Boolean.TRUE);
+			}
+		}
+		case METHOD_WORKSPACE_SYMBOL -> {
+			if (options instanceof WorkspaceSymbolOptions o) { // WorkspaceSymbolRegistrationOptions extends WorkspaceSymbolOptions
+				caps.setWorkspaceSymbolProvider(o);
+			} else {
+				caps.setWorkspaceSymbolProvider(Boolean.TRUE);
+			}
+		}
+		case METHOD_EXECUTE_COMMAND -> {
+			// several executeCommand registrations are legitimate and additive
+			if (options instanceof ExecuteCommandOptions o && o.getCommands() != null) {
+				ExecuteCommandOptions provider = caps.getExecuteCommandProvider();
+				if (provider == null) {
+					provider = new ExecuteCommandOptions(new ArrayList<>());
+					caps.setExecuteCommandProvider(provider);
+				}
+				final List<String> commands = new ArrayList<>(provider.getCommands());
+				for (final String command : o.getCommands()) {
+					if (!commands.contains(command)) {
+						commands.add(command);
+					}
+				}
+				provider.setCommands(commands);
+			}
+		}
+		case METHOD_DID_CHANGE_WORKSPACE_FOLDERS -> {
+			WorkspaceServerCapabilities workspace = caps.getWorkspace();
+			if (workspace == null) {
+				workspace = new WorkspaceServerCapabilities();
+				caps.setWorkspace(workspace);
+			}
+			WorkspaceFoldersOptions folders = workspace.getWorkspaceFolders();
+			if (folders == null) {
+				folders = new WorkspaceFoldersOptions();
+				workspace.setWorkspaceFolders(folders);
+			}
+			folders.setSupported(Boolean.TRUE);
+		}
+		default -> {
+			// METHOD_DID_CHANGE_WATCHED_FILES and unknown methods: no capability change
+		}
 		}
 	}
 
@@ -1293,73 +1380,6 @@ public class LanguageServerWrapper {
 	synchronized void enableWatchedFiles() {
 		if (fileSystemWatcherManager.hasFilePatterns()) {
 			ResourcesPlugin.getWorkspace().addResourceChangeListener(watchedFilesListener, IResourceChangeEvent.POST_CHANGE);
-		}
-	}
-
-	synchronized void setWorkspaceFoldersEnablement(boolean enable) {
-		if (enable == supportsWorkspaceFolderCapability()) {
-			return;
-		}
-		var serverCapabilities = this.serverCapabilities;
-		if (serverCapabilities == null) {
-			serverCapabilities = this.serverCapabilities = new ServerCapabilities();
-		}
-		WorkspaceServerCapabilities workspace = serverCapabilities.getWorkspace();
-		if (workspace == null) {
-			workspace = new WorkspaceServerCapabilities();
-			serverCapabilities.setWorkspace(workspace);
-		}
-		WorkspaceFoldersOptions folders = workspace.getWorkspaceFolders();
-		if (folders == null) {
-			folders = new WorkspaceFoldersOptions();
-			workspace.setWorkspaceFolders(folders);
-		}
-		folders.setSupported(enable);
-		if (enable) {
-			watchProjects();
-		}
-	}
-
-	synchronized void registerCommands(List<String> newCommands) {
-		ServerCapabilities caps = this.getServerCapabilities();
-		if (caps != null) {
-			ExecuteCommandOptions commandProvider = caps.getExecuteCommandProvider();
-			if (commandProvider == null) {
-				commandProvider = new ExecuteCommandOptions(new ArrayList<>());
-				caps.setExecuteCommandProvider(commandProvider);
-			}
-			List<String> existingCommands = commandProvider.getCommands();
-			for (String newCmd : newCommands) {
-				Assert.isLegal(!existingCommands.contains(newCmd), "Command already registered '" + newCmd + "'"); //$NON-NLS-1$ //$NON-NLS-2$
-				existingCommands.add(newCmd);
-			}
-		} else {
-			throw new IllegalStateException("Dynamic command registration failed! Server not yet initialized?"); //$NON-NLS-1$
-		}
-	}
-
-	public void unregisterCapability(UnregistrationParams params) {
-		params.getUnregisterations().forEach(reg -> {
-			String id = reg.getId();
-			Runnable unregistrator;
-			synchronized (dynamicRegistrations) {
-				unregistrator = dynamicRegistrations.get(id);
-				dynamicRegistrations.remove(id);
-			}
-			if (unregistrator != null) {
-				unregistrator.run();
-			}
-		});
-	}
-
-	void unregisterCommands(List<String> cmds) {
-		ServerCapabilities caps = this.getServerCapabilities();
-		if (caps != null) {
-			ExecuteCommandOptions commandProvider = caps.getExecuteCommandProvider();
-			if (commandProvider != null) {
-				List<String> existingCommands = commandProvider.getCommands();
-				existingCommands.removeAll(cmds);
-			}
 		}
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServers.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -254,12 +255,28 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 
 		private final IDocument document;
 
+		private volatile @Nullable URI uri;
+		private volatile boolean uriComputed;
+
 		protected LanguageServerDocumentExecutor(final IDocument document) {
 			this.document = document;
 		}
 
 		public IDocument getDocument() {
 			return this.document;
+		}
+
+		/**
+		 * The document's URI, computed lazily and at most once per executor: {@link #getServers()}
+		 * evaluates the capability filter for every candidate server, and resolving the URI involves
+		 * a file-buffer lookup.
+		 */
+		private @Nullable URI uri() {
+			if (!uriComputed) {
+				uri = LSPEclipseUtils.toUri(document);
+				uriComputed = true;
+			}
+			return uri;
 		}
 
 		CompletableFuture<@Nullable LanguageServerWrapper> connect(CompletableFuture<@Nullable LanguageServerWrapper> wrapperFuture) {
@@ -276,10 +293,12 @@ public abstract class LanguageServers<E extends LanguageServers<E>> {
 
 
 		/**
-		 * Test whether this server supports the requested <code>ServerCapabilities</code>.
+		 * Test whether this server supports the requested <code>ServerCapabilities</code> for this
+		 * executor's document: dynamic capability registrations only count where their
+		 * {@code documentSelector} matches the document.
 		 */
 		private CompletableFuture<@Nullable LanguageServerWrapper> filter(LanguageServerWrapper wrapper) {
-			return wrapper.getServerCapabilitiesAsync() //
+			return wrapper.getServerCapabilitiesAsync(uri()) //
 					.thenApply(sc -> sc != null && getFilter().test(sc) ? wrapper : null);
 		}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/LanguageServiceAccessor.java
@@ -178,7 +178,7 @@ public class LanguageServiceAccessor {
 	private static CompletableFuture<@Nullable LanguageServer> getInitializedLanguageServer(IResource resource,
 			LanguageServerDefinition lsDefinition, @Nullable Predicate<ServerCapabilities> capabilitiesPredicate) {
 		LanguageServerWrapper wrapper = getLSWrapper(resource.getProject(), lsDefinition, resource.getFullPath());
-		return capabilitiesComplyAsync(wrapper, capabilitiesPredicate)
+		return capabilitiesComplyAsync(wrapper, resource.getLocationURI(), capabilitiesPredicate)
 				.thenCompose(complies -> complies ? wrapper.getInitializedServer() : null);
 	}
 
@@ -192,21 +192,26 @@ public class LanguageServiceAccessor {
 	 * @param wrapper
 	 *            the server that's capabilities are tested with
 	 *            {@code capabilitiesPredicate}
+	 * @param uri
+	 *            the URI of the document the capabilities are queried for, or {@code null} for a
+	 *            document-independent query in which every dynamic capability registration applies
 	 * @param capabilitiesPredicate
 	 *            predicate testing the capabilities of {@code wrapper}.
 	 * @return The result of applying the capabilities of {@code wrapper} to
 	 *         {@code capabilitiesPredicate}, or {@code true} if
 	 *         {@code capabilitiesPredicate == null} or
-	 *         {@code wrapper.getServerCapabilities() == null}
+	 *         {@code wrapper.getServerCapabilities(uri) == null}
 	 */
-	private static boolean capabilitiesComply(LanguageServerWrapper wrapper,
+	private static boolean capabilitiesComply(LanguageServerWrapper wrapper, @Nullable URI uri,
 			@Nullable Predicate<ServerCapabilities> capabilitiesPredicate) {
-		return capabilitiesPredicate == null
-				/*
-				 * next null check is workaround for https://github.com/TypeFox/ls-api/issues/47
-				 */
-				|| wrapper.getServerCapabilities() == null
-				|| capabilitiesPredicate.test(castNonNull(wrapper.getServerCapabilities()));
+		if (capabilitiesPredicate == null) {
+			return true;
+		}
+		ServerCapabilities capabilities = wrapper.getServerCapabilities(uri);
+		/*
+		 * next null check is workaround for https://github.com/TypeFox/ls-api/issues/47
+		 */
+		return capabilities == null || capabilitiesPredicate.test(capabilities);
 	}
 
 	/**
@@ -216,6 +221,9 @@ public class LanguageServiceAccessor {
 	 * @param wrapper
 	 *            the server that's capabilities are tested with
 	 *            {@code capabilitiesPredicate}
+	 * @param uri
+	 *            the URI of the document the capabilities are queried for, or {@code null} for a
+	 *            document-independent query in which every dynamic capability registration applies
 	 * @param capabilitiesPredicate
 	 *            predicate testing the capabilities of {@code wrapper}.
 	 * @return The result of applying the capabilities of {@code wrapper} to
@@ -223,10 +231,10 @@ public class LanguageServiceAccessor {
 	 *         {@code capabilitiesPredicate == null}
 	 */
 	private static CompletableFuture<Boolean> capabilitiesComplyAsync(final LanguageServerWrapper wrapper,
-			final @Nullable Predicate<ServerCapabilities> capabilitiesPredicate) {
+			final @Nullable URI uri, final @Nullable Predicate<ServerCapabilities> capabilitiesPredicate) {
 		return capabilitiesPredicate == null //
 				? CompletableFuture.completedFuture(true) //
-				: wrapper.getServerCapabilitiesAsync().thenApply(sC -> sC != null && capabilitiesPredicate.test(sC));
+				: wrapper.getServerCapabilitiesAsync(uri).thenApply(sC -> sC != null && capabilitiesPredicate.test(sC));
 	}
 
 	/**
@@ -251,7 +259,7 @@ public class LanguageServiceAccessor {
 			return Collections.emptyList();
 		}
 
-		List<LanguageServerWrapper> wrappers = getStartedWrappers(file.getProject(), request, true);
+		List<LanguageServerWrapper> wrappers = getStartedWrappers(w -> w.canOperate(project), fileURI, request, true);
 		wrappers.removeIf(
 				wrapper -> !wrapper.isConnectedTo(fileURI) || !lsRegistry.matches(file, wrapper.serverDefinition));
 
@@ -272,7 +280,7 @@ public class LanguageServiceAccessor {
 				}
 				final LanguageServerDefinition serverDefinition = mapping.getValue();
 				final var wrapper = getLSWrapper(project, serverDefinition, file.getFullPath());
-				if (!wrappers.contains(wrapper) && capabilitiesComply(wrapper, request)) {
+				if (!wrappers.contains(wrapper) && capabilitiesComply(wrapper, fileURI, request)) {
 					wrappers.add(wrapper);
 				}
 			}
@@ -420,7 +428,7 @@ public class LanguageServiceAccessor {
 	 */
 	public static List<LanguageServerWrapper> getStartedWrappers(@Nullable Predicate<ServerCapabilities> request,
 			boolean onlyActiveLS) {
-		return getStartedWrappers(w -> true, request, onlyActiveLS);
+		return getStartedWrappers(w -> true, null, request, onlyActiveLS);
 	}
 
 	/**
@@ -429,7 +437,7 @@ public class LanguageServiceAccessor {
 	 */
 	public static List<LanguageServerWrapper> getStartedWrappers(@Nullable IProject project,
 			@Nullable Predicate<ServerCapabilities> request, boolean onlyActiveLS) {
-		return getStartedWrappers(w -> w.canOperate(project), request, onlyActiveLS);
+		return getStartedWrappers(w -> w.canOperate(project), null, request, onlyActiveLS);
 	}
 
 	/**
@@ -438,15 +446,15 @@ public class LanguageServiceAccessor {
 	 */
 	public static List<LanguageServerWrapper> getStartedWrappers(IDocument document,
 			Predicate<ServerCapabilities> request, boolean onlyActiveLS) {
-		return getStartedWrappers(w -> w.canOperate(document), request, onlyActiveLS);
+		return getStartedWrappers(w -> w.canOperate(document), LSPEclipseUtils.toUri(document), request, onlyActiveLS);
 	}
 
 	private static List<LanguageServerWrapper> getStartedWrappers(Predicate<LanguageServerWrapper> canOperatePredicate,
-			@Nullable Predicate<ServerCapabilities> capabilitiesPredicate, boolean onlyActiveLS) {
+			@Nullable URI uri, @Nullable Predicate<ServerCapabilities> capabilitiesPredicate, boolean onlyActiveLS) {
 		final var result = new ArrayList<LanguageServerWrapper>();
 		for (LanguageServerWrapper wrapper : startedServers) {
 			if ((!onlyActiveLS || wrapper.isActive()) && canOperatePredicate.test(wrapper)
-					&& capabilitiesComply(wrapper, capabilitiesPredicate)) {
+					&& capabilitiesComply(wrapper, uri, capabilitiesPredicate)) {
 				result.add(wrapper);
 			}
 		}
@@ -455,27 +463,28 @@ public class LanguageServiceAccessor {
 
 	public static Map<LanguageServerDefinition, CompletableFuture<@Nullable LanguageServerWrapper>> getStartedWrappersAsync(
 			final @Nullable Predicate<ServerCapabilities> request, final boolean onlyActiveLS) {
-		return getStartedWrappersAsync(w -> true, request, onlyActiveLS);
+		return getStartedWrappersAsync(w -> true, null, request, onlyActiveLS);
 	}
 
 	public static Map<LanguageServerDefinition, CompletableFuture<@Nullable LanguageServerWrapper>> getStartedWrappersAsync(
 			final @Nullable IProject project, final @Nullable Predicate<ServerCapabilities> request,
 			final boolean onlyActiveLS) {
-		return getStartedWrappersAsync(w -> w.canOperate(project), request, onlyActiveLS);
+		return getStartedWrappersAsync(w -> w.canOperate(project), null, request, onlyActiveLS);
 	}
 
 	public static Map<LanguageServerDefinition, CompletableFuture<@Nullable LanguageServerWrapper>> getStartedWrappersAsync(final IDocument document,
 			final Predicate<ServerCapabilities> request, final boolean onlyActiveLS) {
-		return getStartedWrappersAsync(w -> w.canOperate(document), request, onlyActiveLS);
+		return getStartedWrappersAsync(w -> w.canOperate(document), LSPEclipseUtils.toUri(document), request,
+				onlyActiveLS);
 	}
 
 	private static Map<LanguageServerDefinition, CompletableFuture<@Nullable LanguageServerWrapper>> getStartedWrappersAsync(
-			final Predicate<LanguageServerWrapper> canOperatePredicate,
+			final Predicate<LanguageServerWrapper> canOperatePredicate, final @Nullable URI uri,
 			final @Nullable Predicate<ServerCapabilities> capabilitiesPredicate, final boolean onlyActiveLS) {
 		final Map<LanguageServerDefinition, CompletableFuture<@Nullable LanguageServerWrapper>> result = new LinkedHashMap<>();
 		for (final LanguageServerWrapper wrapper : startedServers) {
 			if ((!onlyActiveLS || wrapper.isActive()) && canOperatePredicate.test(wrapper)) {
-				result.put(wrapper.serverDefinition, capabilitiesComplyAsync(wrapper, capabilitiesPredicate)
+				result.put(wrapper.serverDefinition, capabilitiesComplyAsync(wrapper, uri, capabilitiesPredicate)
 						.thenApply(complies -> complies ? wrapper : null));
 			}
 		}
@@ -570,8 +579,8 @@ public class LanguageServiceAccessor {
 		if (fileUri != null) {
 			try {
 				getLSWrappers(document).stream() //
-						.filter(wrapper -> wrapper.getServerCapabilities() == null
-								|| capabilityRequest.test(castNonNull(wrapper.getServerCapabilities())))
+						.filter(wrapper -> wrapper.getServerCapabilities(fileUri) == null
+								|| capabilityRequest.test(castNonNull(wrapper.getServerCapabilities(fileUri))))
 						.forEach(wrapper -> {
 							wrapper.connectDocument(document);
 							res.add(new LSPDocumentInfo(fileUri, document, wrapper));

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/DocumentSelectorMatcher.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/DocumentSelectorMatcher.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Cocotec Ltd and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Ahmed Hussain (Cocotec Ltd) - initial implementation
+ *
+ *******************************************************************************/
+package org.eclipse.lsp4e.internal;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.lsp4e.internal.files.PathPatternMatcher;
+import org.eclipse.lsp4j.DocumentFilter;
+
+/**
+ * A compiled LSP {@code DocumentSelector}: decides whether a document URI is matched by the
+ * {@code documentSelector} of a dynamic capability registration.
+ * <p>
+ * Per the LSP specification a selector is a list of {@link DocumentFilter}s combined with OR, and
+ * within one filter the properties that are set ({@code language}, {@code scheme}, {@code pattern})
+ * are combined with AND. A filter's glob pattern matches against the document's absolute path,
+ * except for a {@code RelativePattern}, which matches against the path relative to its own base URI.
+ * <p>
+ * Compile a selector once (when the registration arrives) via {@link #compile(List)} and reuse the
+ * instance for all subsequent queries; the glob matchers are precompiled.
+ */
+public final class DocumentSelectorMatcher {
+
+	/**
+	 * Resolves the LSP language id of the document at a given URI, i.e. the id that is (or would be)
+	 * sent to this filter's server in {@code textDocument/didOpen} for that document.
+	 */
+	@FunctionalInterface
+	public interface LanguageIdResolver {
+		@Nullable
+		String getLanguageId(URI uri);
+	}
+
+	private record CompiledFilter(@Nullable String language, @Nullable String scheme,
+			@Nullable PathPatternMatcher pattern) {
+
+		boolean matches(final URI uri, final LanguageIdResolver languageIdResolver) {
+			if (language != null && !language.equals(languageIdResolver.getLanguageId(uri))) {
+				return false;
+			}
+			if (scheme != null && !scheme.equalsIgnoreCase(uri.getScheme())) {
+				return false;
+			}
+			if (pattern != null && !matchesPattern(uri)) {
+				return false;
+			}
+			return true;
+		}
+
+		private boolean matchesPattern(final URI uri) {
+			final PathPatternMatcher pattern = this.pattern;
+			if (pattern == null) {
+				return false;
+			}
+			final Path path;
+			try {
+				path = Paths.get(uri);
+			} catch (final Exception ex) {
+				// no file-system path can be derived (e.g. non-file scheme): the pattern cannot match
+				return false;
+			}
+			final Path basePath = pattern.getBasePath();
+			if (basePath != null) { // RelativePattern: match relative to its base URI
+				if (!path.startsWith(basePath)) {
+					return false;
+				}
+				return pattern.matches(basePath.relativize(path));
+			}
+			return pattern.matches(path);
+		}
+	}
+
+	private final List<CompiledFilter> filters;
+
+	private DocumentSelectorMatcher(final List<CompiledFilter> filters) {
+		this.filters = filters;
+	}
+
+	/**
+	 * Compiles the {@code documentSelector} of a registration.
+	 *
+	 * @return the compiled selector, or {@code null} for a {@code null} selector, which per the LSP
+	 *         specification means the registration applies to every document the server is used for
+	 */
+	public static @Nullable DocumentSelectorMatcher compile(final @Nullable List<DocumentFilter> documentSelector) {
+		if (documentSelector == null) {
+			return null;
+		}
+		final var filters = new ArrayList<CompiledFilter>(documentSelector.size());
+		for (final DocumentFilter filter : documentSelector) {
+			final String language = isNullOrBlank(filter.getLanguage()) ? null : filter.getLanguage();
+			final String scheme = isNullOrBlank(filter.getScheme()) ? null : filter.getScheme();
+			final PathPatternMatcher pattern = filter.getPattern() == null ? null
+					: PathPatternMatcher.fromGlobPattern(filter.getPattern(), null);
+			if (language == null && scheme == null && pattern == null) {
+				continue; // the spec requires at least one property to be set; ignore invalid filters
+			}
+			filters.add(new CompiledFilter(language, scheme, pattern));
+		}
+		// a non-null selector without any usable filter matches no documents
+		return new DocumentSelectorMatcher(List.copyOf(filters));
+	}
+
+	/** @return whether any filter of this selector matches the document at the given URI */
+	public boolean matches(final URI uri, final LanguageIdResolver languageIdResolver) {
+		return filters.stream().anyMatch(filter -> filter.matches(uri, languageIdResolver));
+	}
+
+	private static boolean isNullOrBlank(final @Nullable String value) {
+		return value == null || value.isBlank();
+	}
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/DynamicRegistrationManager.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/DynamicRegistrationManager.java
@@ -80,37 +80,8 @@ public final class DynamicRegistrationManager {
 		void capabilitiesChanged(@Nullable ServerCapabilities oldCapabilities, ServerCapabilities newCapabilities);
 	}
 
-	private static final String METHOD_CODE_ACTION = "textDocument/codeAction"; //$NON-NLS-1$
-	private static final String METHOD_COMPLETION = "textDocument/completion"; //$NON-NLS-1$
-	private static final String METHOD_FORMATTING = "textDocument/formatting"; //$NON-NLS-1$
-	private static final String METHOD_RANGE_FORMATTING = "textDocument/rangeFormatting"; //$NON-NLS-1$
-	private static final String METHOD_ON_TYPE_FORMATTING = "textDocument/onTypeFormatting"; //$NON-NLS-1$
-	private static final String METHOD_SELECTION_RANGE = "textDocument/selectionRange"; //$NON-NLS-1$
-	private static final String METHOD_TYPE_HIERARCHY = "textDocument/typeHierarchy"; //$NON-NLS-1$
-	private static final String METHOD_WORKSPACE_SYMBOL = "workspace/symbol"; //$NON-NLS-1$
-	private static final String METHOD_EXECUTE_COMMAND = "workspace/executeCommand"; //$NON-NLS-1$
-	private static final String METHOD_DID_CHANGE_WATCHED_FILES = "workspace/didChangeWatchedFiles"; //$NON-NLS-1$
-	private static final String METHOD_DID_CHANGE_WORKSPACE_FOLDERS = "workspace/didChangeWorkspaceFolders"; //$NON-NLS-1$
-
-	/** The LSP4J type of {@code Registration.registerOptions} for each supported method. */
-	private static final Map<String, Class<?>> REGISTRATION_OPTIONS_TYPES = Map.ofEntries( //
-			Map.entry(METHOD_CODE_ACTION, CodeActionRegistrationOptions.class), //
-			Map.entry(METHOD_COMPLETION, CompletionRegistrationOptions.class), //
-			Map.entry(METHOD_FORMATTING, DocumentFormattingRegistrationOptions.class), //
-			Map.entry(METHOD_RANGE_FORMATTING, DocumentRangeFormattingRegistrationOptions.class), //
-			Map.entry(METHOD_ON_TYPE_FORMATTING, DocumentOnTypeFormattingRegistrationOptions.class), //
-			Map.entry(METHOD_SELECTION_RANGE, SelectionRangeRegistrationOptions.class), //
-			Map.entry(METHOD_TYPE_HIERARCHY, TypeHierarchyRegistrationOptions.class), //
-			Map.entry(METHOD_WORKSPACE_SYMBOL, WorkspaceSymbolRegistrationOptions.class), //
-			Map.entry(METHOD_EXECUTE_COMMAND, ExecuteCommandRegistrationOptions.class), //
-			Map.entry(METHOD_DID_CHANGE_WATCHED_FILES, DidChangeWatchedFilesRegistrationOptions.class));
-
-	/** Methods for which several concurrent registrations are legitimate (they do not carry a document selector). */
-	private static final Set<String> ADDITIVE_REGISTRATION_METHODS = Set.of(METHOD_EXECUTE_COMMAND,
-			METHOD_DID_CHANGE_WATCHED_FILES, METHOD_DID_CHANGE_WORKSPACE_FOLDERS);
-
-	private record DynamicRegistration(String method, @Nullable Object options,
-			@Nullable DocumentSelectorMatcher selector) {
+	private record DynamicRegistration(String method, @Nullable SupportedMethod supportedMethod,
+			@Nullable Object options, @Nullable DocumentSelectorMatcher selector) {
 
 		/** @return whether this registration applies to the document at the given URI */
 		boolean matches(final URI uri, final LanguageIdResolver languageIdResolver) {
@@ -248,9 +219,10 @@ public final class DynamicRegistrationManager {
 			for (final Registration reg : params.getRegistrations()) {
 				final String id = reg.getId();
 				final String method = reg.getMethod();
+				final SupportedMethod supported = SupportedMethod.forMethod(method);
 
 				Object options = null;
-				final Class<?> optionsType = REGISTRATION_OPTIONS_TYPES.get(method);
+				final Class<?> optionsType = supported == null ? null : supported.optionsType();
 				if (optionsType != null) {
 					try {
 						options = JsonUtil.registrationOptions(reg, optionsType);
@@ -265,21 +237,20 @@ public final class DynamicRegistrationManager {
 				if (dynamicRegistrations.containsKey(id)) {
 					LanguageServerPlugin.logWarning("A dynamic registration with id '" + id //$NON-NLS-1$
 							+ "' already exists and will be replaced."); //$NON-NLS-1$
-				} else if (!ADDITIVE_REGISTRATION_METHODS.contains(method) && selector == null
+				} else if (supported != null && !supported.isAdditive() && selector == null
 						&& dynamicRegistrations.values().stream()
-								.anyMatch(r -> method.equals(r.method()) && r.selector() == null)) {
+								.anyMatch(r -> r.supportedMethod() == supported && r.selector() == null)) {
 					// several registrations for one method are legitimate when they carry document
 					// selectors; without selectors they all apply everywhere and the most recent wins
 					LanguageServerPlugin.logWarning("Multiple dynamic registrations for '" + method //$NON-NLS-1$
 							+ "' without a document selector. The most recent registration will be used for all documents."); //$NON-NLS-1$
 				}
 
-				if (METHOD_DID_CHANGE_WATCHED_FILES.equals(method)
-						&& options instanceof DidChangeWatchedFilesRegistrationOptions watchedFilesOptions) {
-					fileSystemWatcherManager.registerFileSystemWatchers(id, watchedFilesOptions.getWatchers());
+				if (supported != null) {
+					supported.onRegister(id, options, fileSystemWatcherManager);
 				}
-				// Always record the registration, even without usable options, so unregistration is clean
-				dynamicRegistrations.put(id, new DynamicRegistration(method, options, selector));
+				// Always record the registration, even for unsupported methods, so unregistration is clean
+				dynamicRegistrations.put(id, new DynamicRegistration(method, supported, options, selector));
 			}
 			effectiveCapabilitiesBySelection.clear();
 		}
@@ -294,8 +265,9 @@ public final class DynamicRegistrationManager {
 		synchronized (dynamicRegistrations) {
 			params.getUnregisterations().forEach(unreg -> {
 				final DynamicRegistration removed = dynamicRegistrations.remove(unreg.getId());
-				if (removed != null && METHOD_DID_CHANGE_WATCHED_FILES.equals(removed.method())) {
-					fileSystemWatcherManager.unregisterFileSystemWatchers(unreg.getId());
+				final SupportedMethod supported = removed == null ? null : removed.supportedMethod();
+				if (supported != null) {
+					supported.onUnregister(unreg.getId(), fileSystemWatcherManager);
 				}
 			});
 			effectiveCapabilitiesBySelection.clear();
@@ -323,92 +295,218 @@ public final class DynamicRegistrationManager {
 	}
 
 	private static void applyRegistration(final ServerCapabilities caps, final DynamicRegistration reg) {
-		final Object options = reg.options();
-		switch (reg.method()) {
-		case METHOD_CODE_ACTION -> {
-			if (options instanceof CodeActionRegistrationOptions o) {
-				final var codeActionOptions = new CodeActionOptions(o.getCodeActionKinds());
-				codeActionOptions.setResolveProvider(o.getResolveProvider());
-				caps.setCodeActionProvider(codeActionOptions);
-			} else {
-				caps.setCodeActionProvider(Boolean.TRUE);
-			}
+		final SupportedMethod supported = reg.supportedMethod();
+		if (supported != null) {
+			supported.applyTo(caps, reg.options());
 		}
-		case METHOD_COMPLETION -> {
-			final var completionOptions = new CompletionOptions();
-			if (options instanceof CompletionRegistrationOptions o) {
-				completionOptions.setTriggerCharacters(o.getTriggerCharacters());
-				completionOptions.setAllCommitCharacters(o.getAllCommitCharacters());
-				completionOptions.setResolveProvider(o.getResolveProvider());
-				completionOptions.setCompletionItem(o.getCompletionItem());
-			}
-			caps.setCompletionProvider(completionOptions);
-		}
-		case METHOD_FORMATTING -> caps.setDocumentFormattingProvider(Boolean.TRUE);
-		case METHOD_RANGE_FORMATTING -> caps.setDocumentRangeFormattingProvider(Boolean.TRUE);
-		case METHOD_ON_TYPE_FORMATTING -> {
-			if (options instanceof DocumentOnTypeFormattingRegistrationOptions o && o.getFirstTriggerCharacter() != null) {
-				caps.setDocumentOnTypeFormattingProvider(
-						new DocumentOnTypeFormattingOptions(o.getFirstTriggerCharacter(), o.getMoreTriggerCharacter()));
-			} else {
-				LanguageServerPlugin.logWarning("Ignoring dynamic registration for '" + METHOD_ON_TYPE_FORMATTING //$NON-NLS-1$
-						+ "' without a firstTriggerCharacter"); //$NON-NLS-1$
-			}
-		}
-		case METHOD_SELECTION_RANGE -> {
-			if (options instanceof SelectionRangeRegistrationOptions o) {
-				caps.setSelectionRangeProvider(o);
-			} else {
-				caps.setSelectionRangeProvider(Boolean.TRUE);
-			}
-		}
-		case METHOD_TYPE_HIERARCHY -> {
-			if (options instanceof TypeHierarchyRegistrationOptions o) {
-				caps.setTypeHierarchyProvider(o);
-			} else {
-				caps.setTypeHierarchyProvider(Boolean.TRUE);
-			}
-		}
-		case METHOD_WORKSPACE_SYMBOL -> {
-			if (options instanceof WorkspaceSymbolOptions o) { // WorkspaceSymbolRegistrationOptions extends WorkspaceSymbolOptions
-				caps.setWorkspaceSymbolProvider(o);
-			} else {
-				caps.setWorkspaceSymbolProvider(Boolean.TRUE);
-			}
-		}
-		case METHOD_EXECUTE_COMMAND -> {
-			// several executeCommand registrations are legitimate and additive
-			if (options instanceof ExecuteCommandOptions o && o.getCommands() != null) {
-				ExecuteCommandOptions provider = caps.getExecuteCommandProvider();
-				if (provider == null) {
-					provider = new ExecuteCommandOptions(new ArrayList<>());
-					caps.setExecuteCommandProvider(provider);
+		// unsupported methods: no capability change
+	}
+
+	/**
+	 * The dynamic registration methods LSP4E supports. Each constant carries everything needed to
+	 * handle its method — the LSP method name, the LSP4J type of the {@code registerOptions} payload,
+	 * whether concurrent registrations are additive, how a registration transforms the effective
+	 * {@link ServerCapabilities}, and any register/unregister side effects — so that supporting a new
+	 * method means adding exactly one constant.
+	 */
+	private enum SupportedMethod {
+
+		CODE_ACTION("textDocument/codeAction", CodeActionRegistrationOptions.class, false) { //$NON-NLS-1$
+			@Override
+			void applyTo(final ServerCapabilities caps, final @Nullable Object options) {
+				if (options instanceof CodeActionRegistrationOptions o) {
+					final var codeActionOptions = new CodeActionOptions(o.getCodeActionKinds());
+					codeActionOptions.setResolveProvider(o.getResolveProvider());
+					caps.setCodeActionProvider(codeActionOptions);
+				} else {
+					caps.setCodeActionProvider(Boolean.TRUE);
 				}
-				final List<String> commands = new ArrayList<>(provider.getCommands());
-				for (final String command : o.getCommands()) {
-					if (!commands.contains(command)) {
-						commands.add(command);
+			}
+		},
+
+		COMPLETION("textDocument/completion", CompletionRegistrationOptions.class, false) { //$NON-NLS-1$
+			@Override
+			void applyTo(final ServerCapabilities caps, final @Nullable Object options) {
+				final var completionOptions = new CompletionOptions();
+				if (options instanceof CompletionRegistrationOptions o) {
+					completionOptions.setTriggerCharacters(o.getTriggerCharacters());
+					completionOptions.setAllCommitCharacters(o.getAllCommitCharacters());
+					completionOptions.setResolveProvider(o.getResolveProvider());
+					completionOptions.setCompletionItem(o.getCompletionItem());
+				}
+				caps.setCompletionProvider(completionOptions);
+			}
+		},
+
+		FORMATTING("textDocument/formatting", DocumentFormattingRegistrationOptions.class, false) { //$NON-NLS-1$
+			@Override
+			void applyTo(final ServerCapabilities caps, final @Nullable Object options) {
+				caps.setDocumentFormattingProvider(Boolean.TRUE);
+			}
+		},
+
+		RANGE_FORMATTING("textDocument/rangeFormatting", DocumentRangeFormattingRegistrationOptions.class, false) { //$NON-NLS-1$
+			@Override
+			void applyTo(final ServerCapabilities caps, final @Nullable Object options) {
+				caps.setDocumentRangeFormattingProvider(Boolean.TRUE);
+			}
+		},
+
+		ON_TYPE_FORMATTING("textDocument/onTypeFormatting", DocumentOnTypeFormattingRegistrationOptions.class, false) { //$NON-NLS-1$
+			@Override
+			void applyTo(final ServerCapabilities caps, final @Nullable Object options) {
+				if (options instanceof DocumentOnTypeFormattingRegistrationOptions o
+						&& o.getFirstTriggerCharacter() != null) {
+					caps.setDocumentOnTypeFormattingProvider(new DocumentOnTypeFormattingOptions(
+							o.getFirstTriggerCharacter(), o.getMoreTriggerCharacter()));
+				} else {
+					LanguageServerPlugin.logWarning("Ignoring dynamic registration for '" + method() //$NON-NLS-1$
+							+ "' without a firstTriggerCharacter"); //$NON-NLS-1$
+				}
+			}
+		},
+
+		SELECTION_RANGE("textDocument/selectionRange", SelectionRangeRegistrationOptions.class, false) { //$NON-NLS-1$
+			@Override
+			void applyTo(final ServerCapabilities caps, final @Nullable Object options) {
+				if (options instanceof SelectionRangeRegistrationOptions o) {
+					caps.setSelectionRangeProvider(o);
+				} else {
+					caps.setSelectionRangeProvider(Boolean.TRUE);
+				}
+			}
+		},
+
+		TYPE_HIERARCHY("textDocument/typeHierarchy", TypeHierarchyRegistrationOptions.class, false) { //$NON-NLS-1$
+			@Override
+			void applyTo(final ServerCapabilities caps, final @Nullable Object options) {
+				if (options instanceof TypeHierarchyRegistrationOptions o) {
+					caps.setTypeHierarchyProvider(o);
+				} else {
+					caps.setTypeHierarchyProvider(Boolean.TRUE);
+				}
+			}
+		},
+
+		WORKSPACE_SYMBOL("workspace/symbol", WorkspaceSymbolRegistrationOptions.class, false) { //$NON-NLS-1$
+			@Override
+			void applyTo(final ServerCapabilities caps, final @Nullable Object options) {
+				if (options instanceof WorkspaceSymbolOptions o) { // WorkspaceSymbolRegistrationOptions extends WorkspaceSymbolOptions
+					caps.setWorkspaceSymbolProvider(o);
+				} else {
+					caps.setWorkspaceSymbolProvider(Boolean.TRUE);
+				}
+			}
+		},
+
+		EXECUTE_COMMAND("workspace/executeCommand", ExecuteCommandRegistrationOptions.class, true) { //$NON-NLS-1$
+			@Override
+			void applyTo(final ServerCapabilities caps, final @Nullable Object options) {
+				// several executeCommand registrations are legitimate and additive
+				if (options instanceof ExecuteCommandOptions o && o.getCommands() != null) {
+					ExecuteCommandOptions provider = caps.getExecuteCommandProvider();
+					if (provider == null) {
+						provider = new ExecuteCommandOptions(new ArrayList<>());
+						caps.setExecuteCommandProvider(provider);
 					}
+					final List<String> commands = new ArrayList<>(provider.getCommands());
+					for (final String command : o.getCommands()) {
+						if (!commands.contains(command)) {
+							commands.add(command);
+						}
+					}
+					provider.setCommands(commands);
 				}
-				provider.setCommands(commands);
+			}
+		},
+
+		DID_CHANGE_WATCHED_FILES("workspace/didChangeWatchedFiles", DidChangeWatchedFilesRegistrationOptions.class, //$NON-NLS-1$
+				true) {
+			@Override
+			void applyTo(final ServerCapabilities caps, final @Nullable Object options) {
+				// watched files do not affect the effective capabilities; see onRegister/onUnregister
+			}
+
+			@Override
+			void onRegister(final String id, final @Nullable Object options,
+					final FileSystemWatcherManager watcherManager) {
+				if (options instanceof DidChangeWatchedFilesRegistrationOptions o) {
+					watcherManager.registerFileSystemWatchers(id, o.getWatchers());
+				}
+			}
+
+			@Override
+			void onUnregister(final String id, final FileSystemWatcherManager watcherManager) {
+				watcherManager.unregisterFileSystemWatchers(id);
+			}
+		},
+
+		DID_CHANGE_WORKSPACE_FOLDERS("workspace/didChangeWorkspaceFolders", null, true) { //$NON-NLS-1$
+			@Override
+			void applyTo(final ServerCapabilities caps, final @Nullable Object options) {
+				WorkspaceServerCapabilities workspace = caps.getWorkspace();
+				if (workspace == null) {
+					workspace = new WorkspaceServerCapabilities();
+					caps.setWorkspace(workspace);
+				}
+				WorkspaceFoldersOptions folders = workspace.getWorkspaceFolders();
+				if (folders == null) {
+					folders = new WorkspaceFoldersOptions();
+					workspace.setWorkspaceFolders(folders);
+				}
+				folders.setSupported(Boolean.TRUE);
+			}
+		};
+
+		private static final Map<String, SupportedMethod> BY_METHOD = new HashMap<>();
+		static {
+			for (final SupportedMethod supported : values()) {
+				BY_METHOD.put(supported.method, supported);
 			}
 		}
-		case METHOD_DID_CHANGE_WORKSPACE_FOLDERS -> {
-			WorkspaceServerCapabilities workspace = caps.getWorkspace();
-			if (workspace == null) {
-				workspace = new WorkspaceServerCapabilities();
-				caps.setWorkspace(workspace);
-			}
-			WorkspaceFoldersOptions folders = workspace.getWorkspaceFolders();
-			if (folders == null) {
-				folders = new WorkspaceFoldersOptions();
-				workspace.setWorkspaceFolders(folders);
-			}
-			folders.setSupported(Boolean.TRUE);
+
+		static @Nullable SupportedMethod forMethod(final String method) {
+			return BY_METHOD.get(method);
 		}
-		default -> {
-			// METHOD_DID_CHANGE_WATCHED_FILES and unknown methods: no capability change
+
+		private final String method;
+		private final @Nullable Class<?> optionsType;
+		private final boolean additive;
+
+		SupportedMethod(final String method, final @Nullable Class<?> optionsType, final boolean additive) {
+			this.method = method;
+			this.optionsType = optionsType;
+			this.additive = additive;
 		}
+
+		String method() {
+			return method;
+		}
+
+		/** @return the LSP4J type of this method's {@code Registration.registerOptions}, if it has one */
+		@Nullable
+		Class<?> optionsType() {
+			return optionsType;
+		}
+
+		/**
+		 * @return whether several concurrent registrations for this method are legitimate and combine
+		 *         additively (such methods do not carry a document selector)
+		 */
+		boolean isAdditive() {
+			return additive;
+		}
+
+		/** Applies one registration for this method to the effective capabilities. */
+		abstract void applyTo(ServerCapabilities caps, @Nullable Object options);
+
+		/** Register-time side effect of a registration for this method; no-op by default. */
+		void onRegister(final String id, final @Nullable Object options,
+				final FileSystemWatcherManager watcherManager) {
+		}
+
+		/** Unregister-time side effect of a registration for this method; no-op by default. */
+		void onUnregister(final String id, final FileSystemWatcherManager watcherManager) {
 		}
 	}
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/DynamicRegistrationManager.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/DynamicRegistrationManager.java
@@ -1,0 +1,331 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Cocotec Ltd and others.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *  Ahmed Hussain (Cocotec Ltd) - initial implementation
+ *
+ *******************************************************************************/
+package org.eclipse.lsp4e.internal;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.core.runtime.Assert;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.lsp4e.LanguageServerPlugin;
+import org.eclipse.lsp4e.internal.files.FileSystemWatcherManager;
+import org.eclipse.lsp4j.CodeActionOptions;
+import org.eclipse.lsp4j.CodeActionRegistrationOptions;
+import org.eclipse.lsp4j.CompletionOptions;
+import org.eclipse.lsp4j.CompletionRegistrationOptions;
+import org.eclipse.lsp4j.DidChangeWatchedFilesRegistrationOptions;
+import org.eclipse.lsp4j.DocumentFormattingRegistrationOptions;
+import org.eclipse.lsp4j.DocumentOnTypeFormattingOptions;
+import org.eclipse.lsp4j.DocumentOnTypeFormattingRegistrationOptions;
+import org.eclipse.lsp4j.DocumentRangeFormattingRegistrationOptions;
+import org.eclipse.lsp4j.ExecuteCommandOptions;
+import org.eclipse.lsp4j.ExecuteCommandRegistrationOptions;
+import org.eclipse.lsp4j.Registration;
+import org.eclipse.lsp4j.RegistrationParams;
+import org.eclipse.lsp4j.SelectionRangeRegistrationOptions;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.TypeHierarchyRegistrationOptions;
+import org.eclipse.lsp4j.UnregistrationParams;
+import org.eclipse.lsp4j.WorkspaceFoldersOptions;
+import org.eclipse.lsp4j.WorkspaceServerCapabilities;
+import org.eclipse.lsp4j.WorkspaceSymbolOptions;
+import org.eclipse.lsp4j.WorkspaceSymbolRegistrationOptions;
+
+/**
+ * Tracks the capabilities of a language server: the immutable static capabilities from the
+ * {@code initialize} result plus the live dynamic capability registrations sent by the server via
+ * {@code client/registerCapability} / {@code client/unregisterCapability}.
+ * <p>
+ * The static capabilities are never modified. Instead, the effective capabilities returned by
+ * {@link #getCapabilities()} are recomputed from the static capabilities plus all currently live
+ * registrations whenever a registration is added or removed, so that unregistering never has to
+ * "undo" anything and the result does not depend on the order of (un)registrations. After each
+ * recomputation the {@link CapabilitiesListener} passed to the constructor is notified, so the
+ * owner can apply side effects (e.g. installing workspace listeners).
+ * <p>
+ * This manager also owns the {@link FileSystemWatcherManager}: {@code workspace/didChangeWatchedFiles}
+ * registrations are forwarded to it, and its glob matching is reachable via
+ * {@link #getFileSystemWatcherManager()}.
+ * <p>
+ * Limitation: {@code documentSelector}s are not supported; every registration is assumed to apply
+ * to all documents handled by the server. If a server sends several registrations for the same
+ * method (i.e. for different selectors), the most recent one wins. The decoded registration
+ * options are retained in full, so per-document scoping can be added here later without changing
+ * this class's API towards its owner.
+ */
+public final class DynamicRegistrationManager {
+
+	/** Notified after a register/unregister event has recomputed the effective capabilities. */
+	public interface CapabilitiesListener {
+		void capabilitiesChanged(@Nullable ServerCapabilities oldCapabilities, ServerCapabilities newCapabilities);
+	}
+
+	private static final String METHOD_CODE_ACTION = "textDocument/codeAction"; //$NON-NLS-1$
+	private static final String METHOD_COMPLETION = "textDocument/completion"; //$NON-NLS-1$
+	private static final String METHOD_FORMATTING = "textDocument/formatting"; //$NON-NLS-1$
+	private static final String METHOD_RANGE_FORMATTING = "textDocument/rangeFormatting"; //$NON-NLS-1$
+	private static final String METHOD_ON_TYPE_FORMATTING = "textDocument/onTypeFormatting"; //$NON-NLS-1$
+	private static final String METHOD_SELECTION_RANGE = "textDocument/selectionRange"; //$NON-NLS-1$
+	private static final String METHOD_TYPE_HIERARCHY = "textDocument/typeHierarchy"; //$NON-NLS-1$
+	private static final String METHOD_WORKSPACE_SYMBOL = "workspace/symbol"; //$NON-NLS-1$
+	private static final String METHOD_EXECUTE_COMMAND = "workspace/executeCommand"; //$NON-NLS-1$
+	private static final String METHOD_DID_CHANGE_WATCHED_FILES = "workspace/didChangeWatchedFiles"; //$NON-NLS-1$
+	private static final String METHOD_DID_CHANGE_WORKSPACE_FOLDERS = "workspace/didChangeWorkspaceFolders"; //$NON-NLS-1$
+
+	/** The LSP4J type of {@code Registration.registerOptions} for each supported method. */
+	private static final Map<String, Class<?>> REGISTRATION_OPTIONS_TYPES = Map.ofEntries( //
+			Map.entry(METHOD_CODE_ACTION, CodeActionRegistrationOptions.class), //
+			Map.entry(METHOD_COMPLETION, CompletionRegistrationOptions.class), //
+			Map.entry(METHOD_FORMATTING, DocumentFormattingRegistrationOptions.class), //
+			Map.entry(METHOD_RANGE_FORMATTING, DocumentRangeFormattingRegistrationOptions.class), //
+			Map.entry(METHOD_ON_TYPE_FORMATTING, DocumentOnTypeFormattingRegistrationOptions.class), //
+			Map.entry(METHOD_SELECTION_RANGE, SelectionRangeRegistrationOptions.class), //
+			Map.entry(METHOD_TYPE_HIERARCHY, TypeHierarchyRegistrationOptions.class), //
+			Map.entry(METHOD_WORKSPACE_SYMBOL, WorkspaceSymbolRegistrationOptions.class), //
+			Map.entry(METHOD_EXECUTE_COMMAND, ExecuteCommandRegistrationOptions.class), //
+			Map.entry(METHOD_DID_CHANGE_WATCHED_FILES, DidChangeWatchedFilesRegistrationOptions.class));
+
+	/** Methods for which several concurrent registrations are legitimate (they do not carry a document selector). */
+	private static final Set<String> ADDITIVE_REGISTRATION_METHODS = Set.of(METHOD_EXECUTE_COMMAND,
+			METHOD_DID_CHANGE_WATCHED_FILES, METHOD_DID_CHANGE_WORKSPACE_FOLDERS);
+
+	private record DynamicRegistration(String method, @Nullable Object options) {
+	}
+
+	private final FileSystemWatcherManager fileSystemWatcherManager;
+	private final CapabilitiesListener listener;
+
+	/** The capabilities from the {@code initialize} result; never modified after initialization. */
+	private volatile @Nullable ServerCapabilities staticCapabilities;
+
+	/** The effective capabilities: static capabilities plus live dynamic registrations. */
+	private volatile @Nullable ServerCapabilities capabilities;
+
+	/**
+	 * Live dynamic registrations by registration id, in registration order. See
+	 * {@link #registerCapability(RegistrationParams)}.
+	 */
+	private final Map<String, DynamicRegistration> dynamicRegistrations = new LinkedHashMap<>();
+
+	public DynamicRegistrationManager(final FileSystemWatcherManager fileSystemWatcherManager,
+			final CapabilitiesListener listener) {
+		this.fileSystemWatcherManager = fileSystemWatcherManager;
+		this.listener = listener;
+	}
+
+	/**
+	 * Stores the capabilities from the {@code initialize} result. Until the first dynamic
+	 * registration arrives, the effective capabilities are exactly these. Does not notify the
+	 * {@link CapabilitiesListener}.
+	 */
+	public void setStaticCapabilities(final ServerCapabilities capabilities) {
+		this.staticCapabilities = capabilities;
+		this.capabilities = capabilities;
+	}
+
+	/**
+	 * @return the effective capabilities (static capabilities plus live dynamic registrations), or
+	 *         {@code null} before {@link #setStaticCapabilities(ServerCapabilities)} / after
+	 *         {@link #clear()}
+	 */
+	public @Nullable ServerCapabilities getCapabilities() {
+		return capabilities;
+	}
+
+	/** @return the file-system watcher manager fed by {@code workspace/didChangeWatchedFiles} registrations */
+	public FileSystemWatcherManager getFileSystemWatcherManager() {
+		return fileSystemWatcherManager;
+	}
+
+	/**
+	 * Forgets the static capabilities and all live registrations, including the file-system
+	 * watchers. Does not notify the {@link CapabilitiesListener}.
+	 */
+	public void clear() {
+		this.staticCapabilities = null;
+		this.capabilities = null;
+		synchronized (dynamicRegistrations) {
+			dynamicRegistrations.clear();
+		}
+		fileSystemWatcherManager.clear();
+	}
+
+	/**
+	 * Applies the dynamic capability registrations sent by the server via
+	 * {@code client/registerCapability} and recomputes the effective capabilities.
+	 */
+	public void registerCapability(final RegistrationParams params) {
+		Assert.isNotNull(this.staticCapabilities,
+				"Dynamic capability registration failed! Server not yet initialized?"); //$NON-NLS-1$
+		synchronized (dynamicRegistrations) {
+			for (final Registration reg : params.getRegistrations()) {
+				final String id = reg.getId();
+				final String method = reg.getMethod();
+				if (dynamicRegistrations.containsKey(id)) {
+					LanguageServerPlugin.logWarning("A dynamic registration with id '" + id //$NON-NLS-1$
+							+ "' already exists and will be replaced."); //$NON-NLS-1$
+				} else if (!ADDITIVE_REGISTRATION_METHODS.contains(method)
+						&& dynamicRegistrations.values().stream().anyMatch(r -> method.equals(r.method()))) {
+					LanguageServerPlugin.logWarning("Multiple dynamic registrations for '" + method //$NON-NLS-1$
+							+ "'. Document selectors are not supported; the most recent registration will be used for all documents."); //$NON-NLS-1$
+				}
+
+				Object options = null;
+				final Class<?> optionsType = REGISTRATION_OPTIONS_TYPES.get(method);
+				if (optionsType != null) {
+					try {
+						options = JsonUtil.registrationOptions(reg, optionsType);
+					} catch (final Exception ex) {
+						LanguageServerPlugin.logError("Failed to decode options of dynamic registration for '" + method + "'", ex); //$NON-NLS-1$ //$NON-NLS-2$
+					}
+				}
+
+				if (METHOD_DID_CHANGE_WATCHED_FILES.equals(method)
+						&& options instanceof DidChangeWatchedFilesRegistrationOptions watchedFilesOptions) {
+					fileSystemWatcherManager.registerFileSystemWatchers(id, watchedFilesOptions.getWatchers());
+				}
+				// Always record the registration, even without usable options, so unregistration is clean
+				dynamicRegistrations.put(id, new DynamicRegistration(method, options));
+			}
+		}
+		recomputeCapabilities();
+	}
+
+	/**
+	 * Removes the dynamic capability registrations named by a {@code client/unregisterCapability}
+	 * request and recomputes the effective capabilities.
+	 */
+	public void unregisterCapability(final UnregistrationParams params) {
+		synchronized (dynamicRegistrations) {
+			params.getUnregisterations().forEach(unreg -> {
+				final DynamicRegistration removed = dynamicRegistrations.remove(unreg.getId());
+				if (removed != null && METHOD_DID_CHANGE_WATCHED_FILES.equals(removed.method())) {
+					fileSystemWatcherManager.unregisterFileSystemWatchers(unreg.getId());
+				}
+			});
+		}
+		recomputeCapabilities();
+	}
+
+	/**
+	 * Recomputes the effective capabilities from {@link #staticCapabilities} and the live
+	 * {@link #dynamicRegistrations}, then notifies the {@link CapabilitiesListener}.
+	 */
+	private void recomputeCapabilities() {
+		final ServerCapabilities staticCaps = this.staticCapabilities;
+		if (staticCaps == null) {
+			return;
+		}
+		final ServerCapabilities oldCapabilities = this.capabilities;
+		final ServerCapabilities effective = JsonUtil.deepCopy(staticCaps, ServerCapabilities.class);
+		synchronized (dynamicRegistrations) {
+			// insertion order: for methods registered more than once, the most recent registration wins
+			dynamicRegistrations.values().forEach(reg -> applyRegistration(effective, reg));
+		}
+		this.capabilities = effective;
+		listener.capabilitiesChanged(oldCapabilities, effective);
+	}
+
+	private static void applyRegistration(final ServerCapabilities caps, final DynamicRegistration reg) {
+		final Object options = reg.options();
+		switch (reg.method()) {
+		case METHOD_CODE_ACTION -> {
+			if (options instanceof CodeActionRegistrationOptions o) {
+				final var codeActionOptions = new CodeActionOptions(o.getCodeActionKinds());
+				codeActionOptions.setResolveProvider(o.getResolveProvider());
+				caps.setCodeActionProvider(codeActionOptions);
+			} else {
+				caps.setCodeActionProvider(Boolean.TRUE);
+			}
+		}
+		case METHOD_COMPLETION -> {
+			final var completionOptions = new CompletionOptions();
+			if (options instanceof CompletionRegistrationOptions o) {
+				completionOptions.setTriggerCharacters(o.getTriggerCharacters());
+				completionOptions.setAllCommitCharacters(o.getAllCommitCharacters());
+				completionOptions.setResolveProvider(o.getResolveProvider());
+				completionOptions.setCompletionItem(o.getCompletionItem());
+			}
+			caps.setCompletionProvider(completionOptions);
+		}
+		case METHOD_FORMATTING -> caps.setDocumentFormattingProvider(Boolean.TRUE);
+		case METHOD_RANGE_FORMATTING -> caps.setDocumentRangeFormattingProvider(Boolean.TRUE);
+		case METHOD_ON_TYPE_FORMATTING -> {
+			if (options instanceof DocumentOnTypeFormattingRegistrationOptions o && o.getFirstTriggerCharacter() != null) {
+				caps.setDocumentOnTypeFormattingProvider(
+						new DocumentOnTypeFormattingOptions(o.getFirstTriggerCharacter(), o.getMoreTriggerCharacter()));
+			} else {
+				LanguageServerPlugin.logWarning("Ignoring dynamic registration for '" + METHOD_ON_TYPE_FORMATTING //$NON-NLS-1$
+						+ "' without a firstTriggerCharacter"); //$NON-NLS-1$
+			}
+		}
+		case METHOD_SELECTION_RANGE -> {
+			if (options instanceof SelectionRangeRegistrationOptions o) {
+				caps.setSelectionRangeProvider(o);
+			} else {
+				caps.setSelectionRangeProvider(Boolean.TRUE);
+			}
+		}
+		case METHOD_TYPE_HIERARCHY -> {
+			if (options instanceof TypeHierarchyRegistrationOptions o) {
+				caps.setTypeHierarchyProvider(o);
+			} else {
+				caps.setTypeHierarchyProvider(Boolean.TRUE);
+			}
+		}
+		case METHOD_WORKSPACE_SYMBOL -> {
+			if (options instanceof WorkspaceSymbolOptions o) { // WorkspaceSymbolRegistrationOptions extends WorkspaceSymbolOptions
+				caps.setWorkspaceSymbolProvider(o);
+			} else {
+				caps.setWorkspaceSymbolProvider(Boolean.TRUE);
+			}
+		}
+		case METHOD_EXECUTE_COMMAND -> {
+			// several executeCommand registrations are legitimate and additive
+			if (options instanceof ExecuteCommandOptions o && o.getCommands() != null) {
+				ExecuteCommandOptions provider = caps.getExecuteCommandProvider();
+				if (provider == null) {
+					provider = new ExecuteCommandOptions(new ArrayList<>());
+					caps.setExecuteCommandProvider(provider);
+				}
+				final List<String> commands = new ArrayList<>(provider.getCommands());
+				for (final String command : o.getCommands()) {
+					if (!commands.contains(command)) {
+						commands.add(command);
+					}
+				}
+				provider.setCommands(commands);
+			}
+		}
+		case METHOD_DID_CHANGE_WORKSPACE_FOLDERS -> {
+			WorkspaceServerCapabilities workspace = caps.getWorkspace();
+			if (workspace == null) {
+				workspace = new WorkspaceServerCapabilities();
+				caps.setWorkspace(workspace);
+			}
+			WorkspaceFoldersOptions folders = workspace.getWorkspaceFolders();
+			if (folders == null) {
+				folders = new WorkspaceFoldersOptions();
+				workspace.setWorkspaceFolders(folders);
+			}
+			folders.setSupported(Boolean.TRUE);
+		}
+		default -> {
+			// METHOD_DID_CHANGE_WATCHED_FILES and unknown methods: no capability change
+		}
+		}
+	}
+}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/DynamicRegistrationManager.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/DynamicRegistrationManager.java
@@ -12,7 +12,10 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.internal;
 
+import java.net.URI;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +24,7 @@ import java.util.Set;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.lsp4e.LanguageServerPlugin;
+import org.eclipse.lsp4e.internal.DocumentSelectorMatcher.LanguageIdResolver;
 import org.eclipse.lsp4e.internal.files.FileSystemWatcherManager;
 import org.eclipse.lsp4j.CodeActionOptions;
 import org.eclipse.lsp4j.CodeActionRegistrationOptions;
@@ -37,6 +41,7 @@ import org.eclipse.lsp4j.Registration;
 import org.eclipse.lsp4j.RegistrationParams;
 import org.eclipse.lsp4j.SelectionRangeRegistrationOptions;
 import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.TextDocumentRegistrationOptions;
 import org.eclipse.lsp4j.TypeHierarchyRegistrationOptions;
 import org.eclipse.lsp4j.UnregistrationParams;
 import org.eclipse.lsp4j.WorkspaceFoldersOptions;
@@ -60,11 +65,13 @@ import org.eclipse.lsp4j.WorkspaceSymbolRegistrationOptions;
  * registrations are forwarded to it, and its glob matching is reachable via
  * {@link #getFileSystemWatcherManager()}.
  * <p>
- * Limitation: {@code documentSelector}s are not supported; every registration is assumed to apply
- * to all documents handled by the server. If a server sends several registrations for the same
- * method (i.e. for different selectors), the most recent one wins. The decoded registration
- * options are retained in full, so per-document scoping can be added here later without changing
- * this class's API towards its owner.
+ * {@code documentSelector}s are honoured per document: {@link #getCapabilities(URI)} returns the
+ * effective capabilities for one document, i.e. the static capabilities plus only the registrations
+ * whose selector matches that document's URI. These are cached by the set of matching registration
+ * ids, of which only a handful of distinct values are expected per server. The no-argument
+ * {@link #getCapabilities()} keeps its union semantics — every live registration is assumed to
+ * apply — which is what document-independent (workspace-scoped) callers want. Where several live
+ * registrations for one method match the same document, the most recently registered one wins.
  */
 public final class DynamicRegistrationManager {
 
@@ -102,16 +109,24 @@ public final class DynamicRegistrationManager {
 	private static final Set<String> ADDITIVE_REGISTRATION_METHODS = Set.of(METHOD_EXECUTE_COMMAND,
 			METHOD_DID_CHANGE_WATCHED_FILES, METHOD_DID_CHANGE_WORKSPACE_FOLDERS);
 
-	private record DynamicRegistration(String method, @Nullable Object options) {
+	private record DynamicRegistration(String method, @Nullable Object options,
+			@Nullable DocumentSelectorMatcher selector) {
+
+		/** @return whether this registration applies to the document at the given URI */
+		boolean matches(final URI uri, final LanguageIdResolver languageIdResolver) {
+			// no selector: the registration applies to every document handled by the server
+			return selector == null || selector.matches(uri, languageIdResolver);
+		}
 	}
 
 	private final FileSystemWatcherManager fileSystemWatcherManager;
+	private final LanguageIdResolver languageIdResolver;
 	private final CapabilitiesListener listener;
 
 	/** The capabilities from the {@code initialize} result; never modified after initialization. */
 	private volatile @Nullable ServerCapabilities staticCapabilities;
 
-	/** The effective capabilities: static capabilities plus live dynamic registrations. */
+	/** The effective capabilities: static capabilities plus all live dynamic registrations. */
 	private volatile @Nullable ServerCapabilities capabilities;
 
 	/**
@@ -120,9 +135,17 @@ public final class DynamicRegistrationManager {
 	 */
 	private final Map<String, DynamicRegistration> dynamicRegistrations = new LinkedHashMap<>();
 
+	/**
+	 * Effective capabilities per set of matching registration ids, for documents whose URI is not
+	 * matched by every live registration's selector. Guarded by the {@link #dynamicRegistrations}
+	 * monitor; cleared whenever the registrations or the static capabilities change.
+	 */
+	private final Map<Set<String>, ServerCapabilities> effectiveCapabilitiesBySelection = new HashMap<>();
+
 	public DynamicRegistrationManager(final FileSystemWatcherManager fileSystemWatcherManager,
-			final CapabilitiesListener listener) {
+			final LanguageIdResolver languageIdResolver, final CapabilitiesListener listener) {
 		this.fileSystemWatcherManager = fileSystemWatcherManager;
+		this.languageIdResolver = languageIdResolver;
 		this.listener = listener;
 	}
 
@@ -134,15 +157,65 @@ public final class DynamicRegistrationManager {
 	public void setStaticCapabilities(final ServerCapabilities capabilities) {
 		this.staticCapabilities = capabilities;
 		this.capabilities = capabilities;
+		synchronized (dynamicRegistrations) {
+			effectiveCapabilitiesBySelection.clear();
+		}
 	}
 
 	/**
-	 * @return the effective capabilities (static capabilities plus live dynamic registrations), or
-	 *         {@code null} before {@link #setStaticCapabilities(ServerCapabilities)} / after
-	 *         {@link #clear()}
+	 * @return the effective capabilities assuming every live dynamic registration applies (the union
+	 *         view, appropriate for document-independent queries), or {@code null} before
+	 *         {@link #setStaticCapabilities(ServerCapabilities)} / after {@link #clear()}
 	 */
 	public @Nullable ServerCapabilities getCapabilities() {
 		return capabilities;
+	}
+
+	/**
+	 * Returns the effective capabilities for the document at the given URI: the static capabilities
+	 * plus the live dynamic registrations whose {@code documentSelector} matches the document.
+	 * Results are cached by the set of matching registration ids, so at most one recomputation
+	 * happens per distinct set of applicable registrations.
+	 *
+	 * @param uri the document URI, or {@code null} for the union view of {@link #getCapabilities()}
+	 * @return the effective capabilities, or {@code null} before
+	 *         {@link #setStaticCapabilities(ServerCapabilities)} / after {@link #clear()}
+	 */
+	public @Nullable ServerCapabilities getCapabilities(final @Nullable URI uri) {
+		if (uri == null) {
+			return capabilities;
+		}
+		final ServerCapabilities staticCaps = this.staticCapabilities;
+		if (staticCaps == null) {
+			return null;
+		}
+		synchronized (dynamicRegistrations) {
+			if (dynamicRegistrations.isEmpty()) {
+				return capabilities;
+			}
+			final var matchingIds = new HashSet<String>();
+			dynamicRegistrations.forEach((id, registration) -> {
+				if (registration.matches(uri, languageIdResolver)) {
+					matchingIds.add(id);
+				}
+			});
+			if (matchingIds.size() == dynamicRegistrations.size()) {
+				// every registration applies: identical to the union view (the common case for
+				// servers that send no document selectors)
+				return capabilities;
+			}
+			return effectiveCapabilitiesBySelection.computeIfAbsent(Set.copyOf(matchingIds), key -> {
+				final ServerCapabilities effective = JsonUtil.deepCopy(staticCaps, ServerCapabilities.class);
+				// iterate the registration map, not the key, so that where several matching
+				// registrations exist for one method the most recently registered one wins
+				dynamicRegistrations.forEach((id, registration) -> {
+					if (key.contains(id)) {
+						applyRegistration(effective, registration);
+					}
+				});
+				return effective;
+			});
+		}
 	}
 
 	/** @return the file-system watcher manager fed by {@code workspace/didChangeWatchedFiles} registrations */
@@ -159,6 +232,7 @@ public final class DynamicRegistrationManager {
 		this.capabilities = null;
 		synchronized (dynamicRegistrations) {
 			dynamicRegistrations.clear();
+			effectiveCapabilitiesBySelection.clear();
 		}
 		fileSystemWatcherManager.clear();
 	}
@@ -174,14 +248,6 @@ public final class DynamicRegistrationManager {
 			for (final Registration reg : params.getRegistrations()) {
 				final String id = reg.getId();
 				final String method = reg.getMethod();
-				if (dynamicRegistrations.containsKey(id)) {
-					LanguageServerPlugin.logWarning("A dynamic registration with id '" + id //$NON-NLS-1$
-							+ "' already exists and will be replaced."); //$NON-NLS-1$
-				} else if (!ADDITIVE_REGISTRATION_METHODS.contains(method)
-						&& dynamicRegistrations.values().stream().anyMatch(r -> method.equals(r.method()))) {
-					LanguageServerPlugin.logWarning("Multiple dynamic registrations for '" + method //$NON-NLS-1$
-							+ "'. Document selectors are not supported; the most recent registration will be used for all documents."); //$NON-NLS-1$
-				}
 
 				Object options = null;
 				final Class<?> optionsType = REGISTRATION_OPTIONS_TYPES.get(method);
@@ -192,14 +258,30 @@ public final class DynamicRegistrationManager {
 						LanguageServerPlugin.logError("Failed to decode options of dynamic registration for '" + method + "'", ex); //$NON-NLS-1$ //$NON-NLS-2$
 					}
 				}
+				final DocumentSelectorMatcher selector = options instanceof TextDocumentRegistrationOptions textDocumentOptions
+						? DocumentSelectorMatcher.compile(textDocumentOptions.getDocumentSelector())
+						: null;
+
+				if (dynamicRegistrations.containsKey(id)) {
+					LanguageServerPlugin.logWarning("A dynamic registration with id '" + id //$NON-NLS-1$
+							+ "' already exists and will be replaced."); //$NON-NLS-1$
+				} else if (!ADDITIVE_REGISTRATION_METHODS.contains(method) && selector == null
+						&& dynamicRegistrations.values().stream()
+								.anyMatch(r -> method.equals(r.method()) && r.selector() == null)) {
+					// several registrations for one method are legitimate when they carry document
+					// selectors; without selectors they all apply everywhere and the most recent wins
+					LanguageServerPlugin.logWarning("Multiple dynamic registrations for '" + method //$NON-NLS-1$
+							+ "' without a document selector. The most recent registration will be used for all documents."); //$NON-NLS-1$
+				}
 
 				if (METHOD_DID_CHANGE_WATCHED_FILES.equals(method)
 						&& options instanceof DidChangeWatchedFilesRegistrationOptions watchedFilesOptions) {
 					fileSystemWatcherManager.registerFileSystemWatchers(id, watchedFilesOptions.getWatchers());
 				}
 				// Always record the registration, even without usable options, so unregistration is clean
-				dynamicRegistrations.put(id, new DynamicRegistration(method, options));
+				dynamicRegistrations.put(id, new DynamicRegistration(method, options, selector));
 			}
+			effectiveCapabilitiesBySelection.clear();
 		}
 		recomputeCapabilities();
 	}
@@ -216,6 +298,7 @@ public final class DynamicRegistrationManager {
 					fileSystemWatcherManager.unregisterFileSystemWatchers(unreg.getId());
 				}
 			});
+			effectiveCapabilitiesBySelection.clear();
 		}
 		recomputeCapabilities();
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/JsonUtil.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/JsonUtil.java
@@ -14,9 +14,12 @@ package org.eclipse.lsp4e.internal;
 import java.util.Map;
 import java.util.Objects;
 
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.lsp4j.Registration;
 import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 
 /**
  * Provides a {@link Gson} instance which can properly serialize and deserialize LSP4J JSON-RPC objects
@@ -24,5 +27,39 @@ import com.google.gson.Gson;
 public class JsonUtil {
 
 	public static final Gson LSP4J_GSON = Objects.requireNonNull(new MessageJsonHandler(Map.of()).getGson());
+
+	/**
+	 * Decodes the {@code registerOptions} payload of a dynamic capability {@link Registration}.
+	 * <p>
+	 * The payload is typed as {@code LSPAny} in the protocol, so LSP4J leaves it as a raw
+	 * {@link JsonElement}; the concrete type depends on the registration's {@code method}. An
+	 * in-process server may also hand over the Java object directly, which is returned as-is.
+	 *
+	 * @param registration the registration whose options to decode
+	 * @param type         the LSP4J {@code *RegistrationOptions} type expected for
+	 *                     {@code registration.getMethod()}
+	 * @return the decoded options, or {@code null} if the registration carries no options
+	 * @throws com.google.gson.JsonParseException if the payload does not match {@code type}
+	 */
+	public static <T> @Nullable T registrationOptions(final Registration registration, final Class<T> type) {
+		final Object options = registration.getRegisterOptions();
+		if (options == null) {
+			return null;
+		}
+		if (type.isInstance(options)) {
+			return type.cast(options);
+		}
+		if (options instanceof JsonElement json) {
+			return LSP4J_GSON.fromJson(json, type);
+		}
+		return null;
+	}
+
+	/**
+	 * Creates a deep copy of an LSP4J object by round-tripping it through JSON.
+	 */
+	public static <T> T deepCopy(final T value, final Class<T> type) {
+		return Objects.requireNonNull(LSP4J_GSON.fromJson(LSP4J_GSON.toJsonTree(value, type), type));
+	}
 
 }

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/SupportedFeatures.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/SupportedFeatures.java
@@ -64,6 +64,7 @@ import org.eclipse.lsp4j.SymbolTagSupportCapabilities;
 import org.eclipse.lsp4j.SynchronizationCapabilities;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.eclipse.lsp4j.TypeDefinitionCapabilities;
+import org.eclipse.lsp4j.TypeHierarchyCapabilities;
 import org.eclipse.lsp4j.WindowClientCapabilities;
 import org.eclipse.lsp4j.WindowShowMessageRequestCapabilities;
 import org.eclipse.lsp4j.WorkspaceClientCapabilities;
@@ -141,7 +142,7 @@ public class SupportedFeatures {
 				MarkupKind.PLAINTEXT));
 		textDocumentClientCapabilities.setHover(hoverCapabilities);
 		textDocumentClientCapabilities.setOnTypeFormatting(new OnTypeFormattingCapabilities(true));
-		textDocumentClientCapabilities.setRangeFormatting(new RangeFormattingCapabilities());
+		textDocumentClientCapabilities.setRangeFormatting(new RangeFormattingCapabilities(true));
 		textDocumentClientCapabilities.setReferences(new ReferencesCapabilities());
 		final var renameCapabilities = new RenameCapabilities();
 		renameCapabilities.setPrepareSupport(true);
@@ -156,8 +157,9 @@ public class SupportedFeatures {
 
 		textDocumentClientCapabilities.setSignatureHelp(signatureHelpCapabilities);
 		textDocumentClientCapabilities.setSynchronization(new SynchronizationCapabilities(true, true, true));
-		final var selectionRange = new SelectionRangeCapabilities();
+		final var selectionRange = new SelectionRangeCapabilities(true);
 		textDocumentClientCapabilities.setSelectionRange(selectionRange);
+		textDocumentClientCapabilities.setTypeHierarchy(new TypeHierarchyCapabilities(true));
 		return textDocumentClientCapabilities;
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/files/FileSystemWatcherManager.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/files/FileSystemWatcherManager.java
@@ -28,9 +28,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.lsp4e.LanguageServerPlugin;
 import org.eclipse.lsp4j.FileSystemWatcher;
-import org.eclipse.lsp4j.RelativePattern;
 import org.eclipse.lsp4j.WatchKind;
-import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 // Based on https://github.com/redhat-developer/lsp4ij/blob/6f41f6d22a7146f31e0218cb459513abd5dc16d3/src/main/java/com/redhat/devtools/lsp4ij/features/files/watcher/FileSystemWatcherManager.java
@@ -200,7 +198,7 @@ public final class FileSystemWatcherManager {
 
 		final var matchers = new HashMap<Integer, List<PathPatternMatcher>>();
 		for (final FileSystemWatcher watcher : watchers) {
-			final PathPatternMatcher matcher = getPathPatternMatcher(watcher, basePath);
+			final PathPatternMatcher matcher = PathPatternMatcher.fromGlobPattern(watcher.getGlobPattern(), basePath);
 			if (matcher != null) {
 				final Integer kind = watcher.getKind();
 				tryAddingMatcher(matcher, matchers, kind, WatchKind.Create);
@@ -316,53 +314,6 @@ public final class FileSystemWatcherManager {
 
 		// Path is not under base path, cache negative result
 		basePathToRelativePath.put(basePath, Either.forRight(Boolean.FALSE));
-		return null;
-	}
-
-	private static @Nullable PathPatternMatcher getPathPatternMatcher(final FileSystemWatcher fileSystemMatcher,
-			final @Nullable Path basePath) {
-		final Either<String, RelativePattern> globPattern = fileSystemMatcher.getGlobPattern();
-		if (globPattern.isLeft()) {
-			final String pattern = globPattern.getLeft();
-			return pattern.isBlank() //
-					? null // Invalid pattern, ignore the watcher
-					: new PathPatternMatcher(pattern, basePath);
-		}
-		final RelativePattern relativePattern = globPattern.getRight();
-		// Implement relative pattern like glob string pattern
-		// by waiting for finding a concrete use case.
-		final String pattern = relativePattern.getPattern();
-		if (pattern.isBlank())
-			return null; // Invalid pattern, ignore the watcher
-
-		final Path relativeBasePath = getRelativeBasePath(relativePattern.getBaseUri());
-		if (relativeBasePath == null) {
-			// Invalid baseUri, ignore the watcher
-			return null;
-		}
-		return new PathPatternMatcher(pattern, relativeBasePath);
-	}
-
-	private static @Nullable Path getRelativeBasePath(final @Nullable Either<WorkspaceFolder, String> baseUri) {
-		if (baseUri == null)
-			return null;
-
-		String baseDir = null;
-		if (baseUri.isRight()) {
-			baseDir = baseUri.getRight();
-		} else if (baseUri.isLeft()) {
-			final var workspaceFolder = baseUri.getLeft();
-			baseDir = workspaceFolder.getUri();
-		}
-		if (baseDir == null || baseDir.isBlank())
-			return null;
-
-		try {
-			return Paths.get(URI.create(baseDir));
-		} catch (final Exception ex) {
-			// Invalid baseUri, ignore the watcher
-			LanguageServerPlugin.logWarning(ex.getMessage(), ex);
-		}
 		return null;
 	}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/files/PathPatternMatcher.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/internal/files/PathPatternMatcher.java
@@ -23,9 +23,67 @@ import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.lsp4e.LanguageServerPlugin;
+import org.eclipse.lsp4j.RelativePattern;
+import org.eclipse.lsp4j.WorkspaceFolder;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 // Based on https://github.com/redhat-developer/lsp4ij/blob/6f41f6d22a7146f31e0218cb459513abd5dc16d3/src/main/java/com/redhat/devtools/lsp4ij/features/files/PathPatternMatcher.java
 public final class PathPatternMatcher {
+
+	/**
+	 * Creates a matcher from an LSP glob pattern as used by both {@code FileSystemWatcher.globPattern}
+	 * and {@code DocumentFilter.pattern}.
+	 * <p>
+	 * A plain string pattern is combined with the given {@code stringPatternBasePath} (which may be
+	 * {@code null} for absolute-path matching); a {@link RelativePattern} always uses the base path
+	 * derived from its own {@code baseUri}.
+	 *
+	 * @return the matcher, or {@code null} if the pattern or a relative pattern's base URI is invalid
+	 */
+	public static @Nullable PathPatternMatcher fromGlobPattern(final Either<String, RelativePattern> globPattern,
+			final @Nullable Path stringPatternBasePath) {
+		if (globPattern.isLeft()) {
+			final String pattern = globPattern.getLeft();
+			return pattern.isBlank() //
+					? null // Invalid pattern, ignore it
+					: new PathPatternMatcher(pattern, stringPatternBasePath);
+		}
+		final RelativePattern relativePattern = globPattern.getRight();
+		final String pattern = relativePattern.getPattern();
+		if (pattern.isBlank())
+			return null; // Invalid pattern, ignore it
+
+		final Path relativeBasePath = getRelativeBasePath(relativePattern.getBaseUri());
+		if (relativeBasePath == null) {
+			// Invalid baseUri, ignore the pattern
+			return null;
+		}
+		return new PathPatternMatcher(pattern, relativeBasePath);
+	}
+
+	private static @Nullable Path getRelativeBasePath(final @Nullable Either<WorkspaceFolder, String> baseUri) {
+		if (baseUri == null)
+			return null;
+
+		String baseDir = null;
+		if (baseUri.isRight()) {
+			baseDir = baseUri.getRight();
+		} else if (baseUri.isLeft()) {
+			final var workspaceFolder = baseUri.getLeft();
+			baseDir = workspaceFolder.getUri();
+		}
+		if (baseDir == null || baseDir.isBlank())
+			return null;
+
+		try {
+			return Paths.get(URI.create(baseDir));
+		} catch (final Exception ex) {
+			// Invalid baseUri, ignore the pattern
+			LanguageServerPlugin.logWarning(ex.getMessage(), ex);
+		}
+		return null;
+	}
 
 	private record Parts(List<String> parts, List<Integer> cols) {
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionCompletionProposal.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionCompletionProposal.java
@@ -49,14 +49,10 @@ public class CodeActionCompletionProposal implements ICompletionProposal {
 	static boolean isCodeActionResolveSupported(@Nullable ServerCapabilities capabilities) {
 		if (capabilities != null) {
 			Either<Boolean, CodeActionOptions> caProvider = capabilities.getCodeActionProvider();
-			if (caProvider.isLeft()) {
-				return caProvider.getLeft();
-			} else if (caProvider.isRight()) {
-				CodeActionOptions options = caProvider.getRight();
-				var resolveProvider = options.getResolveProvider();
-				if (resolveProvider != null)
-					return resolveProvider;
-			}
+			// codeAction/resolve is only supported if the server explicitly says so; a plain
+			// "codeActionProvider: true" does not imply it
+			return caProvider != null && caProvider.isRight()
+					&& Boolean.TRUE.equals(caProvider.getRight().getResolveProvider());
 		}
 		return false;
 	}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionCompletionProposal.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionCompletionProposal.java
@@ -61,7 +61,8 @@ public class CodeActionCompletionProposal implements ICompletionProposal {
 	public void apply(IDocument document) {
 		final var fcodeAction = this.fcodeAction;
 		if (fcodeAction != null) {
-			if (isCodeActionResolveSupported(serverWrapper.getServerCapabilities()) && fcodeAction.getEdit() == null) {
+			if (isCodeActionResolveSupported(serverWrapper.getServerCapabilities(LSPEclipseUtils.toUri(document)))
+					&& fcodeAction.getEdit() == null) {
 				// Unresolved code action "edit" property. Resolve it.
 				serverWrapper.execute(ls -> ls.getTextDocumentService().resolveCodeAction(fcodeAction)).thenAccept(this::apply);
 			} else {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionMarkerResolution.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codeactions/CodeActionMarkerResolution.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4e.operations.codeactions;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -78,7 +79,8 @@ public class CodeActionMarkerResolution extends WorkbenchMarkerResolution implem
 		}
 		LanguageServerWrapper wrapper = getLanguageServerWrapper(marker);
 		if (wrapper != null) {
-			resolveCodeAction(wrapper);
+			IResource resource = marker.getResource();
+			resolveCodeAction(wrapper, resource == null ? null : LSPEclipseUtils.toUri(resource));
 			if (codeAction.getEdit() != null) {
 				LSPEclipseUtils.applyWorkspaceEdit(codeAction.getEdit(), codeAction.getTitle());
 			}
@@ -93,7 +95,6 @@ public class CodeActionMarkerResolution extends WorkbenchMarkerResolution implem
 							.exceptionally(t -> reportServerError(serverDefinition, t))
 					);
 				} else  {
-					IResource resource = marker.getResource();
 					if (resource != null) {
 						CommandExecutor.executeCommandClientSide(command, resource);
 					}
@@ -162,10 +163,23 @@ public class CodeActionMarkerResolution extends WorkbenchMarkerResolution implem
 	 *            the wrapper for the language server to send the resolve request to.
 	 */
 	public void resolveCodeAction(LanguageServerWrapper wrapper) {
+		resolveCodeAction(wrapper, null);
+	}
+
+	/**
+	 * Resolve the code action using the given language server wrapper.
+	 *
+	 * @param wrapper
+	 *            the wrapper for the language server to send the resolve request to.
+	 * @param uri
+	 *            the URI of the document the code action belongs to, used to evaluate
+	 *            document-selector-scoped dynamic capability registrations; may be {@code null}
+	 */
+	public void resolveCodeAction(LanguageServerWrapper wrapper, @Nullable URI uri) {
 		if (codeAction.getEdit() != null) {
 			return;
 		}
-		if (CodeActionCompletionProposal.isCodeActionResolveSupported(wrapper.getServerCapabilities())) {
+		if (CodeActionCompletionProposal.isCodeActionResolveSupported(wrapper.getServerCapabilities(uri))) {
 			try {
 				CodeAction resolvedCodeAction = wrapper.execute(ls -> ls.getTextDocumentService().resolveCodeAction(codeAction)).get(2, TimeUnit.SECONDS);
 				if (resolvedCodeAction != null) {

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codelens/LSPCodeMining.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/codelens/LSPCodeMining.java
@@ -17,6 +17,7 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.codemining.LineHeaderCodeMining;
+import org.eclipse.lsp4e.LSPEclipseUtils;
 import org.eclipse.lsp4e.LanguageServerWrapper;
 import org.eclipse.lsp4e.command.CommandExecutor;
 import org.eclipse.lsp4j.CodeLens;
@@ -51,7 +52,7 @@ public class LSPCodeMining extends LineHeaderCodeMining {
 
 	@Override
 	protected CompletableFuture<@Nullable Void> doResolve(ITextViewer viewer, IProgressMonitor monitor) {
-		return languageServerWrapper.getServerCapabilitiesAsync().thenCompose(capabilities -> {
+		return languageServerWrapper.getServerCapabilitiesAsync(LSPEclipseUtils.toUri(document)).thenCompose(capabilities -> {
 			if (capabilities == null) {
 				return CompletableFuture.completedFuture(null);
 			}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSCompletionProposal.java
@@ -363,7 +363,8 @@ public class LSCompletionProposal
 
 	@Override
 	public Object getAdditionalProposalInfo(IProgressMonitor monitor) {
-		if (languageServerWrapper.isActive() && resolvesCompletionItem(languageServerWrapper.getServerCapabilities())) {
+		if (languageServerWrapper.isActive()
+				&& resolvesCompletionItem(languageServerWrapper.getServerCapabilities(LSPEclipseUtils.toUri(document)))) {
 			resolveItem();
 		}
 

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSContentAssistProcessor.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/completion/LSContentAssistProcessor.java
@@ -238,10 +238,11 @@ public class LSContentAssistProcessor implements IContentAssistProcessor {
 			completionTriggerChars = NO_CHARS;
 			contextTriggerChars = NO_CHARS;
 
+			final URI uri = LSPEclipseUtils.toUri(document);
 			completionTriggerCharsFuture = LanguageServers.forDocument(document)
 				.withFilter(capabilities -> capabilities.getCompletionProvider() != null) //
 				.collectAll((w, ls) -> {
-					List<String> triggerChars = castNonNull(w.getServerCapabilities()).getCompletionProvider().getTriggerCharacters();
+					List<String> triggerChars = castNonNull(w.getServerCapabilities(uri)).getCompletionProvider().getTriggerCharacters();
 					completionTriggerChars = mergeTriggers(completionTriggerChars,triggerChars);
 					return CompletableFuture.completedFuture(null);
 			});
@@ -250,7 +251,7 @@ public class LSContentAssistProcessor implements IContentAssistProcessor {
 			contextInformationTriggerCharsFuture = LanguageServers.forDocument(document)
 				.withFilter(capabilities -> capabilities.getSignatureHelpProvider() != null) //
 				.collectAll((w, ls) -> {
-					List<String> triggerChars = castNonNull(w.getServerCapabilities()).getSignatureHelpProvider().getTriggerCharacters();
+					List<String> triggerChars = castNonNull(w.getServerCapabilities(uri)).getSignatureHelpProvider().getTriggerCharacters();
 					contextTriggerChars = mergeTriggers(contextTriggerChars, triggerChars);
 					return CompletableFuture.completedFuture(null);
 			});

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/format/LSPFormatter.java
@@ -56,7 +56,7 @@ public class LSPFormatter {
 		// advertise formatting but return no edits (empty list) are treated as "no result" and formatting
 		// can fall through to the next server (e.g. Vue LS after TS LS on .vue files).
 		long modificationStamp = DocumentUtil.getDocumentModificationStamp(document);
-		return executor.computeFirst((w, ls) -> w.getServerCapabilitiesAsync().thenCompose(capabilities -> {
+		return executor.computeFirst((w, ls) -> w.getServerCapabilitiesAsync(uri).thenCompose(capabilities -> {
 			if (capabilities == null) {
 				return CompletableFuture.completedFuture(null);
 			}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/inlayhint/LSPLineContentCodeMining.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/inlayhint/LSPLineContentCodeMining.java
@@ -93,7 +93,7 @@ public class LSPLineContentCodeMining extends LineContentCodeMining {
 		if (!wrapper.isActive()) // TODO is this check required? if so is it missing in LSPCodeMining.doResolve()?
 			return CompletableFuture.completedFuture(null);
 
-		return wrapper.getServerCapabilitiesAsync().thenCompose(capabilities -> {
+		return wrapper.getServerCapabilitiesAsync(LSPEclipseUtils.toUri(document)).thenCompose(capabilities -> {
 			if (!canResolveInlayHint(capabilities)) {
 				return CompletableFuture.completedFuture(null);
 			}

--- a/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticTokensClient.java
+++ b/org.eclipse.lsp4e/src/org/eclipse/lsp4e/operations/semanticTokens/SemanticTokensClient.java
@@ -46,12 +46,17 @@ public final class SemanticTokensClient {
 						&& LSPEclipseUtils.hasCapability(serverCapabilities.getSemanticTokensProvider().getFull())) //
 				.computeFirst((w, ls) -> ls.getTextDocumentService()
 						.semanticTokensFull(new SemanticTokensParams(LSPEclipseUtils.toTextDocumentIdentifier(uri)))
-						.thenApply(semanticTokens -> callback.apply(getSemanticTokensLegend(w), semanticTokens)));
+						.thenApply(semanticTokens -> callback.apply(getSemanticTokensLegend(w, uri), semanticTokens)));
 	}
 
 	// public for testing
 	public @Nullable SemanticTokensLegend getSemanticTokensLegend(final LanguageServerWrapper wrapper) {
-		ServerCapabilities serverCapabilities = wrapper.getServerCapabilities();
+		return getSemanticTokensLegend(wrapper, null);
+	}
+
+	public @Nullable SemanticTokensLegend getSemanticTokensLegend(final LanguageServerWrapper wrapper,
+			final @Nullable URI uri) {
+		ServerCapabilities serverCapabilities = wrapper.getServerCapabilities(uri);
 		if (serverCapabilities != null) {
 			SemanticTokensWithRegistrationOptions semanticTokensProvider = serverCapabilities
 					.getSemanticTokensProvider();


### PR DESCRIPTION

Fixes eclipse-lsp4e/lsp4e#1565.

The current implementation of dynamic registration (in `LanguageServerWrapper.registerCapability()`) has a number of issues:
 * Not all the methods attempted to use the detailed `RegistrationOptions` payload
    * In many cases we just ignored the payload and set the capability to `true`, resulting in dynamic registration support that was less rich than if the same features were registered statically
    * In other cases we weren't deserializing and applying the payload correctly
 * Our implementation didn't take into account the fact that dynamic registration payloads are _not_ necessarily the same as the corresponding subtree of `ServerCapabilities` - in many cases they are a mixin of the corresponding subtree and `TextDocumentRegistrationOptions` which carries a document selector. This has the following consequences:
   * Dynamic registrations can be sent multiple times for the same method but with different document selectors, so our implementation of registration/deregistration could result in a lot of cross talk, especially if overlapping registrations were not unregistered in strict reverse order
   * The way that we query server capabilities in the consuming code elsewhere in LSP4e assumes that there is only ever a single, monolithic server capabilities for a given language server, with no way of taking into account that these might vary by document.
   * The `mixin` types are not always of the correct type to be inserted into the appropriate subtree of `ServerCapabilities`: this is an awkward side-effect of how LSP4j has to translate the LSP schema into Java DTOs - some corner cases that are trivially expressed in Typescript's structural typing system are harder in Java's nominally-typed single-rooted hierarchy.

The solution:
 * Store all dynamic registrations sent by the server, with their correctly unserialised `RegistrationOption` payloads
 * For each method/payload type, have specialised code that can copy properties across into `ServerCapabilities` if the dynamic types are not directly insertable.
 * Add the ability to compute an 'effective server capabiltiies', taking into account the document type, and hence work out which document selectors are in play. We compute these capabilities lazily, and cache them according to the set of registrations that apply: the bet is that for a given language server there are only going to be a handful at most of different file types that it might support in different ways (eg source files and cargo files for Rust).
 * Use the document URI to retrieve the effective server capabilities in LanguageServerDocumentExecutor.filter()`

Also made the following miscellaneous related changes:
- codeAction/resolve is only used when resolveProvider is explicitly true (a second bug uncovered in #1565 - we were assuming that the coarse-grained 'code action supported' capability, with no fine-grained information, meant resolveProvider could be assumed, whereas it should only be invoke if explicitly declared by the server)
- advertise dynamicRegistration for rangeFormatting, selectionRange and typeHierarchy, which registerCapability already handled
- MockTextDocumentService gains a hook to observe codeAction/resolve